### PR TITLE
adding continuous profiling

### DIFF
--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -36,4 +36,4 @@ RUN yarn build
 
 EXPOSE 4000
 
-CMD ["/bin/bash", "-c", "bundle exec rails s -b 0.0.0.0 -p 4000"]
+CMD ["/bin/bash", "-c", "bundle exec ddtracerb exec rails s -b 0.0.0.0 -p 4000"]

--- a/services/backend/Gemfile
+++ b/services/backend/Gemfile
@@ -98,3 +98,5 @@ gem 'sassc', github: 'sass/sassc-ruby', group: :development
 
 # monitoring
 gem 'ddtrace', require: 'ddtrace/auto_instrument'
+# needed for Datadog Continuous Profiler
+gem 'google-protobuf', '~> 3.0'

--- a/services/backend/config/initializers/datadog-tracer.rb
+++ b/services/backend/config/initializers/datadog-tracer.rb
@@ -2,4 +2,5 @@ Datadog.configure do |c|
   c.env = ENV['DD_ENV'] || 'development'
   c.service = ENV['DD_SERVICE'] || 'store-backend'
   c.tracing.sampling.default_rate = 1.0
+  c.profiling.enabled = true
 end


### PR DESCRIPTION
## Description

Please, provide here a short description.

The `Gemfile` for the backend already uses latest version of the Ruby ddtrace library, so Continuous Profiling is supported. This configures Profiling to be enabled. In Ruby this requires adding `google-protobuf`, enabling in the initializer file (this can be overridden with env, and adding `ddtracerb exec` to the app execution command.

## Checklist

Before you move on, make sure that:

- [X] No unintended changes are included
- [X] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [X] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [X] Proper labels assigned. Use `WIP` label to indicate that state
