### PR TITLE
Update workflows to include arm build platform

### DIFF
--- a/.github/workflows/ads-java.yml
+++ b/.github/workflows/ads-java.yml
@@ -44,7 +44,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ./services/ads/java
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/ads-java:latest
 

--- a/.github/workflows/ads.yml
+++ b/.github/workflows/ads.yml
@@ -44,7 +44,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ./services/ads/python
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/ads:latest
 

--- a/.github/workflows/attackbox.yml
+++ b/.github/workflows/attackbox.yml
@@ -44,7 +44,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ./services/attackbox
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/attackbox:latest
 

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./services/ads
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/auth:latest
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -44,7 +44,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ./services/backend
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/backend:latest
 

--- a/.github/workflows/discounts.yml
+++ b/.github/workflows/discounts.yml
@@ -44,7 +44,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ./services/discounts
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/discounts:latest
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -44,7 +44,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ./services/frontend
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/frontend:latest
 

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./services/nginx
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/nginx:latest
 

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   frontend:
-    image: public.ecr.aws/x2b9z2t7/storedog/frontend:1.0.2
+    image: public.ecr.aws/x2b9z2t7/storedog/frontend:1.0.8
     command: yarn dev
     volumes:
       - "../../services/frontend/site:/storedog-app/site"
@@ -12,7 +12,7 @@ services:
     networks:
       - storedog-net
   nginx:
-    image: public.ecr.aws/x2b9z2t7/storedog/nginx:1.0.2
+    image: public.ecr.aws/x2b9z2t7/storedog/nginx:1.0.8
     restart: always
     ports:
       - "80:80"
@@ -44,14 +44,12 @@ services:
     networks:
       - storedog-net
   web:
-    image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.7
+    image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.8
     depends_on:
       - 'postgres'
       - 'redis'
     ports:
       - '${DOCKER_HOST_WEB_PORT:-4000}:4000'
-    volumes:
-      - 'bundle_cache:/bundle'
     environment:
       REDIS_URL: redis://redis:6379/0
       DB_HOST: postgres
@@ -60,14 +58,12 @@ services:
     networks:
       - storedog-net
   worker:
-    image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.7
+    image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.8
     command: bundle exec sidekiq -C config/sidekiq.yml
     depends_on:
       - 'postgres'
       - 'redis'
       - 'web'
-    volumes:
-      - 'bundle_cache:/bundle'
     environment:
       REDIS_URL: redis://redis:6379/0
       DB_HOST: postgres
@@ -76,7 +72,7 @@ services:
     networks:
       - storedog-net
   ads:
-    image: public.ecr.aws/x2b9z2t7/storedog/ads:1.0.7
+    image: public.ecr.aws/x2b9z2t7/storedog/ads:1.0.8
     command: flask run --port=${ADS_PORT} --host=0.0.0.0
     depends_on:
       - postgres
@@ -96,7 +92,7 @@ services:
     networks:
       - storedog-net
   discounts:
-    image: public.ecr.aws/x2b9z2t7/storedog/discounts:1.0.7
+    image: public.ecr.aws/x2b9z2t7/storedog/discounts:1.0.8
     command: ./my-wrapper-script.sh ${DISCOUNTS_PORT}
     depends_on:
       - postgres
@@ -144,5 +140,5 @@ networks:
     driver: bridge
     ipam:
       config:
-        - subnet: 172.18.0.0/16
-          gateway: 172.18.0.1
+        - subnet: 172.43.0.0/16
+          gateway: 172.43.0.1


### PR DESCRIPTION
This will publish `arm` and `amd` versions of the images to fix some local build issues when using tagged ECR images. I tested the `arm`  context locally via the following cmd:

```
docker build --platform linux/arm64 --tag public.ecr.aws/x2b9z2t7/storedog/backend:arm-test-1 --no-cache ./services/backend
```

Additionally I updated the docker compose to have the correct subnet CIDR block

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
