### PR TITLE
Ads (Java) fix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,5 @@
 ## Description
+Provide a short description of what your changes entail and what services are affected.
 
-Please, provide here a short description.
-Consider including things like:
-- An overview of why the work is taking place (with any relevant links); don’t assume familiarity with the history.
-- Major changes made and a high-level idea of the chosen approach.
-- All the compromises made (in _performance, readability, maintainability etc._)
-  to achieve the expected result if any
-
-## Checklist
-
-Before you move on, make sure that:
-
-- [ ] No unintended changes are included
-- [ ] Spelling is correct
-- [ ] There are tests covering new/changed functionality
-- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
-- [ ] Proper labels assigned. Use `WIP` label to indicate that state
+## How to test
+Provide the steps needed to test and verify your changes.

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     networks:
       - storedog-net
   web:
-    image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.8
+    image: public.ecr.aws/x2b9z2t7/storedog/backend:latest
     depends_on:
       - 'postgres'
       - 'redis'
@@ -58,7 +58,7 @@ services:
     networks:
       - storedog-net
   worker:
-    image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.8
+    image: public.ecr.aws/x2b9z2t7/storedog/backend:latest
     command: bundle exec sidekiq -C config/sidekiq.yml
     depends_on:
       - 'postgres'
@@ -71,24 +71,16 @@ services:
       DISABLE_SPRING: 1
     networks:
       - storedog-net
-  ads:
-    image: public.ecr.aws/x2b9z2t7/storedog/ads:1.0.8
-    command: flask run --port=${ADS_PORT} --host=0.0.0.0
-    depends_on:
-      - postgres
+  ads-java:
+    image: public.ecr.aws/x2b9z2t7/storedog/ads-java:1.0.8
     environment:
-      - FLASK_APP=ads.py
-      - FLASK_DEBUG=1
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_HOST=postgres
-      - DD_SERVICE=ads
+      - DD_SERVICE=ads-java
       - DD_AGENT_HOST=dd-agent
       - DD_LOGS_INJECTION=true
       - DD_TRACE_ANALYTICS_ENABLED=true
       - DD_PROFILING_ENABLED=true
     ports:
-      - "${ADS_PORT}:${ADS_PORT}"
+      - "3030:8080"
     networks:
       - storedog-net
   discounts:

--- a/services/ads/java/Dockerfile
+++ b/services/ads/java/Dockerfile
@@ -23,4 +23,4 @@ COPY --from=TEMP_BUILD_IMAGE $APP_HOME/build/libs/$ARTIFACT_NAME .
 
 RUN wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
 
-ENTRYPOINT exec java -javaagent:/usr/app/dd-java-agent.jar -Ddd.logs.injection=true -Ddd.service=ads-java -Ddd.env=dev -jar ${ARTIFACT_NAME} 
+ENTRYPOINT exec java -javaagent:/usr/app/dd-java-agent.jar -jar ${ARTIFACT_NAME} 

--- a/services/ads/java/src/main/java/adsjava/AdsJavaApplication.java
+++ b/services/ads/java/src/main/java/adsjava/AdsJavaApplication.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RestController
 public class AdsJavaApplication {
 
-  @CrossOrigin(origins = "http://localhost:3000")
+  @CrossOrigin(origins = {"http://localhost", "http://localhost:3000"})
   @RequestMapping(
     value = "/banners/{id}",
     produces = MediaType.IMAGE_JPEG_VALUE
@@ -36,7 +36,7 @@ public class AdsJavaApplication {
 		return "Hello from Advertisements (Java)";
 	}
 
-  @CrossOrigin(origins = "http://localhost:3000")
+  @CrossOrigin(origins = {"http://localhost", "http://localhost:3000"})
   @RequestMapping(
     value = "/ads",
     produces = MediaType.APPLICATION_JSON_VALUE

--- a/services/ads/java/src/main/java/adsjava/AdsJavaApplication.java
+++ b/services/ads/java/src/main/java/adsjava/AdsJavaApplication.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RestController
 public class AdsJavaApplication {
 
-  @CrossOrigin(origins = {"http://localhost", "http://localhost:3000"})
+  @CrossOrigin(origins = {"*"})
   @RequestMapping(
     value = "/banners/{id}",
     produces = MediaType.IMAGE_JPEG_VALUE
@@ -36,7 +36,7 @@ public class AdsJavaApplication {
 		return "Hello from Advertisements (Java)";
 	}
 
-  @CrossOrigin(origins = {"http://localhost", "http://localhost:3000"})
+  @CrossOrigin(origins = {"*"})
   @RequestMapping(
     value = "/ads",
     produces = MediaType.APPLICATION_JSON_VALUE

--- a/services/backend/Gemfile.lock
+++ b/services/backend/Gemfile.lock
@@ -189,6 +189,7 @@ GEM
       devise (>= 2.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    dogstatsd-ruby (5.5.0)
     doorkeeper (5.5.4)
       railties (>= 5)
     dotenv (2.7.6)
@@ -245,6 +246,7 @@ GEM
     globalid (1.0.0)
       activesupport (>= 5.0)
     glyphicons (1.0.2)
+    google-protobuf (3.22.0)
     hashdiff (1.0.1)
     highline (2.0.3)
     hotwire-rails (0.1.3)
@@ -671,8 +673,10 @@ DEPENDENCIES
   bootsnap
   dalli
   ddtrace
+  dogstatsd-ruby
   dotenv-rails (~> 2.1, >= 2.1.1)
   font_assets
+  google-protobuf (~> 3.0)
   letter_opener
   listen
   oj


### PR DESCRIPTION
## How to test

1. Pull down this branch locally
2. Before starting the containers, you will need to define the required env vars. Run the following command to copy the env var template:
```cp .env.template .env && cp .env.template ./deploy/docker-compose/.env && cp .env.template ./services/frontend/site/.env.local```
4. Open the .env file under the project root and enter the values for the variables. The default values should all work except for the empty DD_API_KEY, which is required to run the DD agent.
5. Open the ./services/frontend/site/.env.local file and enter the values for the variables. Change the `NEXT_PUBLIC_ADS_PORT` to be `3030` which is the port which `ads-java` is being served from

5. Rebuild the containers via `docker-compose build`

6. Start the app via `docker-compose up`

7. After containers are healthy, go to http://localhost and confirm that ads are being served in the middle banner of the page.

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
