### PR TITLE
added support for runtime metrics

### DIFF
--- a/services/backend/Gemfile
+++ b/services/backend/Gemfile
@@ -98,3 +98,4 @@ gem 'sassc', github: 'sass/sassc-ruby', group: :development
 
 # monitoring
 gem 'ddtrace', require: 'ddtrace/auto_instrument'
+gem 'dogstatsd-ruby', require: 'datadog/statsd'


### PR DESCRIPTION
## Description

The DogStatsD library is required for runtime metrics in Ruby. An environment variable is still needed to activate it.

## Checklist

Before you move on, make sure that:

- [X] No unintended changes are included
- [X] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [X] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [X] Proper labels assigned. Use `WIP` label to indicate that state
