### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+# Local runs for storedog
+local-start:
+	if [[ "$(PROFILE)" ]]; then \
+		rm -rf ./services/backend/tmp ./services/backend/log; \
+		docker-compose --profile "$(PROFILE)" up --force-recreate -d; \
+	else \
+		rm -rf ./services/backend/tmp ./services/backend/log; \
+		docker-compose up --force-recreate -d; \
+	fi
+
+local-stop:
+	if [[ "$(PROFILE)" ]]; then \
+		docker-compose --profile "$(PROFILE)" down; \
+	else \
+		docker-compose down; \
+	fi
+	

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Open the `.env` file under the project root and enter the values for the variabl
 **3.**
 Open the `./services/frontend/site/.env.local` file and enter the values for the variables. The default values should all work except for the empty `NEXT_PUBLIC_DD_APPLICATION_KEY` and `NEXT_PUBLIC_CLIENT_TOKEN`, which are required to enable RUM.
 
-**4.** Start the app: `docker-compose up`
+**4.** Start the app: `make local-start`
+    **4a.** If you wan to work with a profile for a specific lab, you can pass that in as an argument `make local-start PROFILE=<profile-name>`
+**5.** When you're finished you can run `make local-stop` or `make local-stop PROFILE=<profile-name>` if working with a profile
 
 ## Image publication
 Images are stored in our public ECR repo `public.ecr.aws/x2b9z2t7`. On PR merges, only the affected services will be pushed to the ECR repo, using the `latest` tag. For example, if you only made changes to the `backend` service, then only the `backend` Github workflow will trigger and publish `public.ecr.aws/x2b9z2t7/storedog/backend:latest`. 


### PR DESCRIPTION
## Description
Adds a `Makefile` to simplify the startup process and clean up some files that can cause intermittent bugs in the `backend` containers

## How to test
- Pull down this branch
- Run `make local-start`
- Run `make local-stop`
- Run `make local-start PROFILE=dbm`
- Run `make local-stop PROFILE=dbm`

This should start and stop all containers as expected in the background


