### PR TITLE
Increase yarn timeout

### DIFF
--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -2,4 +2,4 @@ FROM node:16.18.0 as builder
 WORKDIR /storedog-app
 COPY . .
 EXPOSE 3000
-RUN ["yarn","install"]
+RUN ["yarn","install", "--network-timeout 1000000"]


### PR DESCRIPTION
## Description
Frontend job keeps failing due to a slow network connection in the gh worker: https://github.com/DataDog/storedog/actions/runs/4621886137/jobs/8210234468

This will increase the timeout so the package can be grabbed, this appears to be a common problem with yarn in workflows https://stackoverflow.com/questions/51508364/yarn-there-appears-to-be-trouble-with-your-network-connection-retrying

## How to test
- Pull this branch
- Delete the frontend image from docker
- run `make start-local`
- ensure everything runs as expected


