### PR TITLE
Update FE workflow

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -40,11 +40,20 @@ jobs:
         username: ${{ secrets.AWS_ACCESS_KEY_ID }}
         password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-    - name: Build and push
+    - name: Build and push AMD
       uses: docker/build-push-action@v2
       with:
         context: ./services/frontend
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         push: true
-        tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/frontend:latest
+        tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/frontend-amd:latest
+
+    - name: Build and push ARM
+      uses: docker/build-push-action@v2
+      continue-on-error: true
+      with:
+        context: ./services/frontend
+        platforms: linux/arm64
+        push: true
+        tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/frontend-arm:latest
 

--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -2,4 +2,4 @@ FROM node:16.18.0 as builder
 WORKDIR /storedog-app
 COPY . .
 EXPOSE 3000
-RUN ["yarn","install", "--network-timeout 1000000"]
+RUN ["yarn","install"]


### PR DESCRIPTION
## Description

- Update the github action to build the `arm` and `amd` separately and tag as `frontend-amd` and `frontend-arm`. 

- Update the dockerfile to remove the timeout setting since it just prolonged the job failure and didn't fix the issue.

- Allow the arm job to fail (we need to debug this and get it fixed, but it is causing a block for other projects)

## How to test

We need to merge this to run the job, no way to really manually test.


