### PR TITLE
Udpate dbm and auth urls

### DIFF
--- a/services/frontend/site/components/common/Navbar/Navbar.tsx
+++ b/services/frontend/site/components/common/Navbar/Navbar.tsx
@@ -16,8 +16,16 @@ interface NavbarProps {
     links?: Link[]
 }
 
-const authUrl = `${process.env.NEXT_PUBLIC_AUTH_ROUTE}:${process.env.NEXT_PUBLIC_AUTH_PORT}/email`
-const dbmUrl = `${process.env.NEXT_PUBLIC_DBM_ROUTE}:${process.env.NEXT_PUBLIC_DBM_PORT}/get-item`
+let authUrl = `${process.env.NEXT_PUBLIC_AUTH_ROUTE}/email`
+let dbmUrl = `${process.env.NEXT_PUBLIC_DBM_ROUTE}/get-item`
+
+if (process.env.NEXT_PUBLIC_AUTH_PORT) {
+    authUrl = `${process.env.NEXT_PUBLIC_AUTH_ROUTE}:${process.env.NEXT_PUBLIC_AUTH_PORT}/email`
+}
+
+if (process.env.NEXT_PUBLIC_DBM_PORT) {
+    dbmUrl = `${process.env.NEXT_PUBLIC_DBM_ROUTE}:${process.env.NEXT_PUBLIC_DBM_PORT}/get-item`
+}
 
 const Navbar: FC<NavbarProps> = ({ links }) => {
     // Set the input value from the form to state


### PR DESCRIPTION
## Description
Updates the URLs for dbm and auth to only include the port if the env var is defined

## How to test
- Pull this branch
- run `docker-compose --profile dbm up`
- goto `localhost:3000`
- ensure the product order ticker shows up
- run `docker-compose --profile dbm down`
- goto your `.env.local` file and remove the `NEXT_PUBLIC_DBM_PORT`
- run `docker-compose --profile dbm up`
- check the network tab for the site now and you should see that the `get-item` route is failing and the url should show without the port now


