### PR TITLE
bumps rum sdk to fix apm trace correlation

### DIFF
--- a/services/frontend/package-lock.json
+++ b/services/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@datadog/browser-rum": "^5.8.0",
+        "@datadog/browser-rum": "^5.12.0",
         "@radix-ui/react-dropdown-menu": "^0.1.6",
         "@react-spring/web": "^9.4.1",
         "autoprefixer": "^10.4.2",
@@ -528,20 +528,20 @@
       }
     },
     "node_modules/@datadog/browser-core": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-5.8.0.tgz",
-      "integrity": "sha512-aNMSB+tLu5aKm/uzswy5d6KDgGtMs2uMxsGWdZ3lmqorEHLXk5kPNTEVRJfeE49EJaWaxiTYQuuuLo0c5S0rUA=="
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-5.12.0.tgz",
+      "integrity": "sha512-DVV64OqKMxfJXvHJrHjcCji0guytLGBun9jf7tugXN1ylMNurloV5sF1KW1W1Pb0BuEMiJsuyz1DEIqZHO3z0w=="
     },
     "node_modules/@datadog/browser-rum": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-5.8.0.tgz",
-      "integrity": "sha512-WtWRQa41d/G4TRs4PwbMM82i56Fsjov9b/B1go0ocqIqUkaJYdTBqQCIcJo3xmCZrgmxSlPiPgEgB5shhVDXxA==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-5.12.0.tgz",
+      "integrity": "sha512-k6U4LoUTDozkACHwp9Wk99fTSsKdr9fGxAKAdsco9kAnlCX0QOjbkF/taIincAeMvePRf0BVK+HIUaHZQ9YVLQ==",
       "dependencies": {
-        "@datadog/browser-core": "5.8.0",
-        "@datadog/browser-rum-core": "5.8.0"
+        "@datadog/browser-core": "5.12.0",
+        "@datadog/browser-rum-core": "5.12.0"
       },
       "peerDependencies": {
-        "@datadog/browser-logs": "5.8.0"
+        "@datadog/browser-logs": "5.12.0"
       },
       "peerDependenciesMeta": {
         "@datadog/browser-logs": {
@@ -550,11 +550,11 @@
       }
     },
     "node_modules/@datadog/browser-rum-core": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-5.8.0.tgz",
-      "integrity": "sha512-UtWVR7z8qXvt0Ik10KjjG6Ueck1JLOXcfY00Vv2TttQ73hepL1NUlSDjdMyobySc/990ROvWkCYTIvhtqWFDFw==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-5.12.0.tgz",
+      "integrity": "sha512-JHOH3ZBjtnFYA7TMFOE3hUQurubC9ISidhrFvZf+gxbqtYGt8HTqe7pwJpOW2xqfQn1Us3lZyui8/LHayUZLdg==",
       "dependencies": {
-        "@datadog/browser-core": "5.8.0"
+        "@datadog/browser-core": "5.12.0"
       }
     },
     "node_modules/@datadog/native-appsec": {

--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -13,7 +13,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@datadog/browser-rum": "^5.8.0",
+    "@datadog/browser-rum": "^5.12.0",
     "@radix-ui/react-dropdown-menu": "^0.1.6",
     "@react-spring/web": "^9.4.1",
     "autoprefixer": "^10.4.2",


### PR DESCRIPTION
RUM <> APM trace correlation was broken in the SDK and has been fixed. This PR updates to use that version. 