### PR TITLE
Disable GH Action permissions

### DIFF
--- a/.github/workflows/ads-java.yml
+++ b/.github/workflows/ads-java.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - services/ads/java/**
   workflow_dispatch:
-    branches: [ main, ccole/gh-workflow-perm ]
+    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/ads-java.yml
+++ b/.github/workflows/ads-java.yml
@@ -1,12 +1,14 @@
 name: Ads - Java
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]
     paths:
       - services/ads/java/**
   workflow_dispatch:
-    branches: [ main ]
+    branches: [ main, ccole/gh-workflow-perm ]
 
 defaults:
   run:

--- a/.github/workflows/ads.yml
+++ b/.github/workflows/ads.yml
@@ -1,5 +1,7 @@
 name: Ads - Python
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/attackbox.yml
+++ b/.github/workflows/attackbox.yml
@@ -1,5 +1,7 @@
 name: Attackbox
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -1,5 +1,7 @@
 name: Auth
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,5 +1,7 @@
 name: Backend
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/dbm.yml
+++ b/.github/workflows/dbm.yml
@@ -1,5 +1,7 @@
 name: DBM
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/discounts.yml
+++ b/.github/workflows/discounts.yml
@@ -1,5 +1,7 @@
 name: Discounts
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,5 +1,7 @@
 name: Frontend
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -1,5 +1,7 @@
 name: Nginx
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -1,5 +1,7 @@
 name: postgres
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Publish release
 
+permissions: {}
+
 # Only release on a new tag that is a version number.
 on:
   push:


### PR DESCRIPTION
## Description
<!--Provide a short description of what changes are being made and what services are being affected. Please include a Jira card link if applicable-->
The GH Actions do not need access to the general permission scope.

## Motivation
https://datadoghq.atlassian.net/browse/VULN-8176

## How to test
<!--Provide the steps needed to test and verify your changes-->
Test run of a workflow with all permissions disabled. It built and deployed the `ads-java` service as expected
https://github.com/DataDog/storedog/actions/runs/10635427517

Ref: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions

