### PR TITLE
[TRAIN-2677] Switch container image registry target from ECR to GHCR

### DIFF
--- a/.github/workflows/ads-java.yml
+++ b/.github/workflows/ads-java.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - services/ads/java/**
   workflow_dispatch:
-    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/ads-java.yml
+++ b/.github/workflows/ads-java.yml
@@ -30,7 +30,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      id: login-ecr
+      id: login-ghcr
       uses: docker/login-action@v3
       with:
         registry: ghcr.io

--- a/.github/workflows/ads-java.yml
+++ b/.github/workflows/ads-java.yml
@@ -19,6 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
     - name: Checkout
@@ -27,13 +30,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Login to ECR
+    - name: Login to GHCR
       id: login-ecr
       uses: docker/login-action@v3
       with:
-        registry: public.ecr.aws
-        username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
       uses: docker/build-push-action@v5
@@ -41,5 +44,5 @@ jobs:
         context: ./services/ads/java
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/ads-java:latest
+        tags: ghcr.io/DataDog/storedog/ads-java:latest
 

--- a/.github/workflows/ads.yml
+++ b/.github/workflows/ads.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - services/ads/python/**
   workflow_dispatch:
-    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/ads.yml
+++ b/.github/workflows/ads.yml
@@ -19,6 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
     - name: Checkout
@@ -27,13 +30,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Login to ECR
+    - name: Login to GHCR
       id: login-ecr
       uses: docker/login-action@v3
       with:
-        registry: public.ecr.aws
-        username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
       uses: docker/build-push-action@v5
@@ -41,5 +44,5 @@ jobs:
         context: ./services/ads/python
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/ads:latest
+        tags: ghcr.io/DataDog/storedog/ads:latest
 

--- a/.github/workflows/ads.yml
+++ b/.github/workflows/ads.yml
@@ -30,7 +30,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      id: login-ecr
+      id: login-ghcr
       uses: docker/login-action@v3
       with:
         registry: ghcr.io

--- a/.github/workflows/attackbox.yml
+++ b/.github/workflows/attackbox.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - services/attackbox/**
   workflow_dispatch:
-    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/attackbox.yml
+++ b/.github/workflows/attackbox.yml
@@ -19,6 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
     - name: Checkout
@@ -27,13 +30,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Login to ECR
+    - name: Login to GHCR
       id: login-ecr
       uses: docker/login-action@v3
       with:
-        registry: public.ecr.aws
-        username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
       uses: docker/build-push-action@v5
@@ -41,5 +44,5 @@ jobs:
         context: ./services/attackbox
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/attackbox:latest
+        tags: ghcr.io/DataDog/storedog/attackbox:latest
 

--- a/.github/workflows/attackbox.yml
+++ b/.github/workflows/attackbox.yml
@@ -30,7 +30,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      id: login-ecr
+      id: login-ghcr
       uses: docker/login-action@v3
       with:
         registry: ghcr.io

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -19,6 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -27,13 +30,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to ECR
+      - name: Login to GHCR
         id: login-ecr
         uses: docker/login-action@v3
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -41,5 +44,5 @@ jobs:
           context: ./services/auth
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/auth:latest
+          tags: ghcr.io/DataDog/storedog/auth:latest
 

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - services/auth/**
   workflow_dispatch:
-    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
-        id: login-ecr
+        id: login-ghcr
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - services/backend/**
   workflow_dispatch:
-    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -19,6 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
     - name: Checkout
@@ -27,13 +30,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Login to ECR
+    - name: Login to GHCR
       id: login-ecr
       uses: docker/login-action@v3
       with:
-        registry: public.ecr.aws
-        username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
       uses: docker/build-push-action@v5
@@ -41,5 +44,5 @@ jobs:
         context: ./services/backend
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/backend:latest
+        tags: ghcr.io/DataDog/storedog/backend:latest
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -30,7 +30,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      id: login-ecr
+      id: login-ghcr
       uses: docker/login-action@v3
       with:
         registry: ghcr.io

--- a/.github/workflows/dbm.yml
+++ b/.github/workflows/dbm.yml
@@ -14,11 +14,15 @@ defaults:
   run:
     working-directory: dbm
 
+
 jobs:
 
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -27,13 +31,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to ECR
+      - name: Login to GHCR
         id: login-ecr
         uses: docker/login-action@v3
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -41,5 +45,5 @@ jobs:
           context: ./services/dbm
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/dbm:latest
+          tags: ghcr.io/DataDog/storedog/dbm:latest
 

--- a/.github/workflows/dbm.yml
+++ b/.github/workflows/dbm.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
-        id: login-ecr
+        id: login-ghcr
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/dbm.yml
+++ b/.github/workflows/dbm.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - services/dbm/**
   workflow_dispatch:
-    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/discounts.yml
+++ b/.github/workflows/discounts.yml
@@ -19,6 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
     - name: Checkout
@@ -27,13 +30,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Login to ECR
+    - name: Login to GHCR
       id: login-ecr
       uses: docker/login-action@v3
       with:
-        registry: public.ecr.aws
-        username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
       uses: docker/build-push-action@v5
@@ -41,5 +44,4 @@ jobs:
         context: ./services/discounts
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/discounts:latest
-
+        tags: ghcr.io/DataDog/storedog/discounts:latest

--- a/.github/workflows/discounts.yml
+++ b/.github/workflows/discounts.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - services/discounts/**
   workflow_dispatch:
-    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/discounts.yml
+++ b/.github/workflows/discounts.yml
@@ -30,7 +30,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      id: login-ecr
+      id: login-ghcr
       uses: docker/login-action@v3
       with:
         registry: ghcr.io

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,6 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
     - name: Checkout
@@ -27,13 +30,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Login to ECR
+    - name: Login to GHCR
       id: login-ecr
       uses: docker/login-action@v3
       with:
-        registry: public.ecr.aws
-        username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
       uses: docker/build-push-action@v5
@@ -41,5 +44,5 @@ jobs:
         context: ./services/frontend
         platforms: linux/arm64, linux/amd64
         push: true
-        tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/frontend:latest
+        tags: ghcr.io/DataDog/storedog/frontend:latest
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,7 +30,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      id: login-ecr
+      id: login-ghcr
       uses: docker/login-action@v3
       with:
         registry: ghcr.io

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - services/frontend/**
   workflow_dispatch:
-    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - services/nginx/**
   workflow_dispatch:
-    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
-        id: login-ecr
+        id: login-ghcr
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -19,6 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -27,13 +30,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to ECR
+      - name: Login to GHCR
         id: login-ecr
         uses: docker/login-action@v3
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -41,5 +44,5 @@ jobs:
           context: ./services/nginx
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/nginx:latest
+          tags: ghcr.io/DataDog/storedog/nginx:latest
 

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -19,6 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -27,13 +30,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to ECR
+      - name: Login to GHCR
         id: login-ecr
         uses: docker/login-action@v3
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -41,5 +44,5 @@ jobs:
           context: ./services/postgres
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/postgres:latest
+          tags: ghcr.io/DataDog/storedog/postgres:latest
 

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - services/postgres/**
   workflow_dispatch:
-    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
-        id: login-ecr
+        id: login-ghcr
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ jobs:
   publish_service_containers:
     name: Publish all images
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,29 +29,29 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to ECR
+      - name: Login to GHCR
         id: login-ecr
         uses: docker/login-action@v3
         with:
-           registry: public.ecr.aws
-           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download, Tag, and Push Service Images
         run: |
           TAG=${GITHUB_REF/refs\/tags\//}
 
           IMAGES=(
-            ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/backend
-            ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/discounts
-            ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/ads
-            ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/ads-java
-            ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/attackbox
-            ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/auth
-            ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/nginx
-            ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/frontend
-            ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/dbm
-            ${{ secrets.PUBLIC_ECR_REGISTRY }}/storedog/postgres
+            ghcr.io/DataDog/storedog/backend
+            ghcr.io/DataDog/storedog/discounts
+            ghcr.io/DataDog/storedog/ads
+            ghcr.io/DataDog/storedog/ads-java
+            ghcr.io/DataDog/storedog/attackbox
+            ghcr.io/DataDog/storedog/auth
+            ghcr.io/DataDog/storedog/nginx
+            ghcr.io/DataDog/storedog/frontend
+            ghcr.io/DataDog/storedog/dbm
+            ghcr.io/DataDog/storedog/postgres
           )
 
           for i in "${IMAGES[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
-        id: login-ecr
+        id: login-ghcr
         uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Description
Replaces Elastic Container Registry with Github Container Registry in GH Actions workflows.

## How to test
Trigger the workflows manually for all except `release`, which we'll need to trigger on push.

I did successfully test the `discounts` workflow in a fork to confirm the changes.


