### PR TITLE
K8s manifest updates

### DIFF
--- a/k8s-manifests/README.md
+++ b/k8s-manifests/README.md
@@ -82,7 +82,8 @@ export REGISTRY_URL=localhost:5000
 > Building and pushing containers to the local registry needs to be done on the worker node.
 
 ```bash
-docker build -t $REGISTRY_URL/backend:latest ./services/backend && docker push $REGISTRY_URL/backend:latest
+SERVICE_NAME=ads
+docker build -t $REGISTRY_URL/$SERVICE_NAME:latest ./services/$SERVICE_NAME && docker push $REGISTRY_URL/$SERVICE_NAME:latest
 ```
 
 ## Prerequisites
@@ -140,7 +141,7 @@ export SD_TAG=1.4.0
 export DD_VERSION_ADS=1.0.0
 export DD_VERSION_BACKEND=1.0.0
 export DD_VERSION_DISCOUNTS=1.0.0
-export DD_VERSION_NGINX=1.0.0
+export DD_VERSION_NGINX=1.28.0
 export NEXT_PUBLIC_DD_SERVICE_FRONTEND=store-frontend
 export NEXT_PUBLIC_DD_VERSION_FRONTEND=1.0.0
 export DD_ENV=development
@@ -174,7 +175,7 @@ The storedog-app definition files contain variables which need to be set before 
 
 1. **Deploy Cluster Components (one-time setup per cluster):**
 
-This single command installs the storage provisioner and the ingress controller.
+Install the storage provisioner and the ingress controller.
 
 ```bash
 kubectl apply -R -f k8s-manifests/cluster-setup/

--- a/k8s-manifests/storedog-app/configmaps/feature-flags-config.yaml
+++ b/k8s-manifests/storedog-app/configmaps/feature-flags-config.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: feature-flags-config
-  namespace: default
   labels:
     app: frontend
     managed-by: storedog
@@ -32,4 +31,4 @@ data:
         "name": "product-card-frustration",
         "active": false
       }
-    ] 
+    ]

--- a/k8s-manifests/storedog-app/configmaps/feature-flags-config.yaml
+++ b/k8s-manifests/storedog-app/configmaps/feature-flags-config.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags-config
+  namespace: default
+  labels:
+    app: frontend
+    managed-by: storedog
+    purpose: feature-flags
+    environment: development
+    tier: application
+data:
+  featureFlags.config.json: |
+    [
+      {
+        "id": "1",
+        "name": "dbm",
+        "active": false
+      },
+      {
+        "id": "2",
+        "name": "error-tracking",
+        "active": false
+      },
+      {
+        "id": "3",
+        "name": "api-errors",
+        "active": false
+      },
+      {
+        "id": "4",
+        "name": "product-card-frustration",
+        "active": false
+      }
+    ] 

--- a/k8s-manifests/storedog-app/deployments/backend.yaml
+++ b/k8s-manifests/storedog-app/deployments/backend.yaml
@@ -24,7 +24,7 @@ spec:
       labels:
         app: backend
       annotations:
-        ad.datadoghq.com/backend.logs: '[{"source": "ruby"}, "auto_multi_line_detection":true }]'
+        ad.datadoghq.com/backend.logs: '[{"source": "ruby", "auto_multi_line_detection":true}]'
     spec:
       volumes:
         - name: apmsocketpath
@@ -39,7 +39,6 @@ spec:
           image: ${REGISTRY_URL}/backend:${SD_TAG}
           ports:
             - containerPort: 4000
-          command: ["bundle", "exec", "rails", "s", "-b", "0.0.0.0", "-p", "4000"]
           env:
             - name: REDIS_URL
               valueFrom:

--- a/k8s-manifests/storedog-app/deployments/discounts.yaml
+++ b/k8s-manifests/storedog-app/deployments/discounts.yaml
@@ -39,10 +39,11 @@ spec:
           image: ${REGISTRY_URL}/discounts:${SD_TAG}
           ports:
             - containerPort: 2814
-          command: ["ddtrace-run", "flask", "run", "--port=2814", "--host=0.0.0.0"]
           env:
             - name: FLASK_APP
               value: "discounts.py"
+            - name: DISCOUNTS_PORT
+              value: "2814"
             - name: FLASK_DEBUG
               value: "0"
             - name: POSTGRES_PASSWORD

--- a/k8s-manifests/storedog-app/deployments/frontend.yaml
+++ b/k8s-manifests/storedog-app/deployments/frontend.yaml
@@ -30,6 +30,9 @@ spec:
         - name: apmsocketpath
           hostPath:
             path: /var/run/datadog/
+        - name: feature-flags-config
+          configMap:
+            name: feature-flags-config
       initContainers:
         - name: wait-for-backend
           image: busybox
@@ -106,6 +109,9 @@ spec:
           volumeMounts:
             - name: apmsocketpath
               mountPath: /var/run/datadog
+            - name: feature-flags-config
+              mountPath: /app/featureFlags.config.json
+              subPath: featureFlags.config.json
           livenessProbe:
             httpGet:
               path: /

--- a/k8s-manifests/storedog-app/deployments/nginx.yaml
+++ b/k8s-manifests/storedog-app/deployments/nginx.yaml
@@ -30,8 +30,8 @@ spec:
         tags.datadoghq.com/service: service-proxy
         tags.datadoghq.com/version: 1.28.0
       annotations:
-        ad.datadoghq.com/nginx.logs: '[{"source": "nginx"}]'
-        ad.datadoghq.com/nginx.checks: |
+        ad.datadoghq.com/service-proxy.logs: '[{"source": "nginx"}]'
+        ad.datadoghq.com/service-proxy.checks: |
           {
             "nginx": {
             "init_config": {},

--- a/k8s-manifests/storedog-app/deployments/worker.yaml
+++ b/k8s-manifests/storedog-app/deployments/worker.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: worker
       annotations:
-        ad.datadoghq.com/worker.logs: '[{"source": "ruby"}, "auto_multi_line_detection":true }]'
+        ad.datadoghq.com/worker.logs: '[{"source": "ruby", "auto_multi_line_detection":true}]'
     spec:
       volumes:
         - name: apmsocketpath

--- a/k8s-manifests/storedog-app/ingress/nginx-ingress.yaml
+++ b/k8s-manifests/storedog-app/ingress/nginx-ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: storedog-ingress
-  namespace: storedog
 spec:
   ingressClassName: nginx
   # All traffic that doesn't match a more specific rule below will

--- a/k8s-manifests/storedog-app/statefulsets/postgres.yaml
+++ b/k8s-manifests/storedog-app/statefulsets/postgres.yaml
@@ -32,21 +32,14 @@ spec:
         tags.datadoghq.com/service: store-db
         tags.datadoghq.com/version: "15.0"
       annotations:
-        ad.datadoghq.com/postgres.logs: |
-          [{
-            "source": "postgresql",
-            "service": "postgres",
-            "auto_multi_line_detection": true,
-            "path": "/var/log/pg_log/postgresql*.json",
-            "type": "file"
-          }]
+        ad.datadoghq.com/postgres.logs: '[{"source": "postgresql", "auto_multi_line_detection":true}]'
         ad.datadoghq.com/postgres.checks: |
-          [{
+          {
             "postgres": {
             "init_config": {},
             "instances": [{"host":"%%host%%", "port":5432, "username":"datadog", "password":"datadog"}]
             }
-          }]
+          }
     spec:
       containers:
         - name: postgres

--- a/k8s-manifests/storedog-app/statefulsets/postgres.yaml
+++ b/k8s-manifests/storedog-app/statefulsets/postgres.yaml
@@ -15,6 +15,7 @@ kind: StatefulSet
 metadata:
   name: postgres
   labels:
+    tags.datadoghq.com/env: ${DD_ENV}
     tags.datadoghq.com/service: store-db
     tags.datadoghq.com/version: "15.0"
 spec:
@@ -27,23 +28,25 @@ spec:
     metadata:
       labels:
         app: postgres
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/service: store-db
         tags.datadoghq.com/version: "15.0"
       annotations:
         ad.datadoghq.com/postgres.logs: |
-          {
+          [{
             "source": "postgresql",
-            "auto_multi_line_detection":true,
+            "service": "postgres",
+            "auto_multi_line_detection": true,
             "path": "/var/log/pg_log/postgresql*.json",
             "type": "file"
-          }
+          }]
         ad.datadoghq.com/postgres.checks: |
-          {
+          [{
             "postgres": {
             "init_config": {},
             "instances": [{"host":"%%host%%", "port":5432, "username":"datadog", "password":"datadog"}]
             }
-          }
+          }]
     spec:
       containers:
         - name: postgres

--- a/k8s-manifests/storedog-app/statefulsets/redis.yaml
+++ b/k8s-manifests/storedog-app/statefulsets/redis.yaml
@@ -15,6 +15,7 @@ kind: StatefulSet
 metadata:
   name: redis
   labels:
+    tags.datadoghq.com/env: ${DD_ENV}
     tags.datadoghq.com/service: redis
     tags.datadoghq.com/version: "6.2"
 spec:
@@ -27,6 +28,7 @@ spec:
     metadata:
       labels:
         app: redis
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/service: redis
         tags.datadoghq.com/version: "6.2"
       annotations:


### PR DESCRIPTION
## Description
Updates to the K8s manifests to resolve some issues with data collection.
Added the feature flag settings to a ConfigMap
Resolved issues with logging and integrations collection
Added DD_ENV where missing

## How to test
Steps are outline in the readme. It's important to note that unlike Docker compose, K8s won't build container images. Images must be pre-built and hosted in a registry. For development, you can run a local registry. Then build and push images. The images must be built and pushed on the `worker` node as that is where the services will run and look for `localhost`.

The [development K8s Sandbox](https://learn.datadoghq.com/courses/take/sandbox-k8s-testing/texts/64160521-dev-testing-and-troubleshooting-kubernetes-images) is currently set to test. The services files from `main` branch are used to build and push to the local registry. You can also set the registry url to the live public version. Follow the steps in the readme to setup the Datadog operator and start Storedog.

Use the **Storedog** tab to the right of the `worker` tabs to load the site. Again, the pods are running on the worker node.


