### PR TITLE
created k8s manifest files

### DIFF
--- a/services/dbm/Dockerfile
+++ b/services/dbm/Dockerfile
@@ -24,4 +24,4 @@ ENV FLASK_APP=dbm.py
 
 # Start the app using ddtrace so we have profiling and tracing
 ENTRYPOINT ["ddtrace-run"]
-CMD gunicorn --bind 0.0.0.0:7578 dbm:app
+CMD ["gunicorn", "--bind", "0.0.0.0:7595", "dbm:app"]

--- a/services/dbm/README.md
+++ b/services/dbm/README.md
@@ -145,7 +145,7 @@ DD_DBM_PROPAGATION_MODE=full
 
 #### Script files
 
-There are two shell script files in the `./scripts` directory. This need to be added to the lab files. Ensure they are executable (`chmod +x <filename>).
+There are two shell script files in the `./scripts` directory. This need to be added to the lab files. Ensure they are executable `chmod +x <filename>`.
 
 These scripts use `psql` to query the database. They can be added as a cron job to continually run on the host. Use the following command to install the required programs.
 
@@ -158,16 +158,16 @@ Add the script to cron:
 
 ```bash
 echo "* * * * * /root/dbm_query_one.sh > /dev/null 2>&1" |crontab -
-(crontab -l;echo "*/2 * * * * /root/dmb_query_two.sh > /dev/null 2>&1") |crontab -
+(crontab -l;echo "*/2 * * * * /root/dbm_query_two.sh > /dev/null 2>&1") |crontab -
 ```
 
 ### Kubernetes
 
-The `dbm/k8s-manifest` directory is additive to the version at the the root of the repo. These files will add the `store-dbm` service and the configurations needed to collect DBM data.
+The `dbm/k8s-manifest` directory is additive to the version at the root of the repo. These files will add the `store-dbm` service and the configurations needed to collect DBM data.
 
 In this scenario, Storedog and the Datadog Agent are expected to be in the same namespace. The steps below assume that Storedog will run in the `default` namespace. This simplifies Postgres log collection.
 
-The definition yaml files use environment variables to define the image URL and other settings. These values are set using `envsubst`. You can edit the files to hardcode these values if needed rather than using `envsubst`.
+The manifest YAML files use environment variables such as ${DD_ENV} and ${REGISTRY_URL}. These are substituted using envsubst during deployment. If you prefer, you can edit the YAMLs directly to hardcode these values.
 
 #### A note on log collection
 

--- a/services/dbm/bootstrap.py
+++ b/services/dbm/bootstrap.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from flask_cors import CORS
 from models import Items, Preorder_Items, db
 from faker import Faker
 import random
@@ -13,6 +14,7 @@ DB_HOST = os.environ['POSTGRES_HOST']
 def create_app():
     """Create a Flask application"""
     app = Flask(__name__)
+    CORS(app)
     app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://' + \
         DB_USERNAME + ':' + DB_PASSWORD + '@' + DB_HOST + '/' + DB_USERNAME
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False

--- a/services/dbm/k8s-manifests/cluster-setup/storage/shared-pg-logs-pvc.yaml
+++ b/services/dbm/k8s-manifests/cluster-setup/storage/shared-pg-logs-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-pg-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: standard

--- a/services/dbm/k8s-manifests/datadog/datadog-agent.yaml
+++ b/services/dbm/k8s-manifests/datadog/datadog-agent.yaml
@@ -1,0 +1,117 @@
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    secretBackend:
+      command: "/readsecret_multiple_providers.sh"
+      enableGlobalPermissions: true
+    clusterName: storedog-k8s
+    site: datadoghq.com
+    kubelet:
+      tlsVerify: false
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+      appSecret:
+        secretName: datadog-secret
+        keyName: app-key
+  features:
+    logCollection: # Logs
+      enabled: true
+      containerCollectAll: true
+    clusterChecks: # Required for integrations
+      enabled: true
+    # Datadog security features
+    # cspm: # Cloud Security Posture Management
+    #   enabled: true
+    #   hostBenchmarks:
+    #     enabled: true
+    # cws: # Cloud Workload Security
+    #   enabled: true
+    # sbom: # Software Bill of Materials
+    #   enabled: true
+    #   containerImage:
+    #     enabled: true
+  override:
+    nodeAgent:
+      containers:
+        agent:
+          volumeMounts:
+            - name: shared-pg-logs # For Postgres log collection
+              mountPath: /var/log/pg_log_shared
+              readOnly: true
+          env:
+      volumes:
+        - name: shared-pg-logs # For Postgres log collection
+          persistentVolumeClaim:
+            claimName: shared-pg-logs
+      extraConfd:
+        configDataMap: # Integration configurations
+          nginx_ingress_controller.yaml: |- # nginx-ingress-controller integration
+            ad_identifiers:
+              - controller
+            init_config:
+            instances:
+              - prometheus_url: http://%%host%%:10254/metrics
+                collect_nginx_histograms: true
+            logs:
+              - service: controller
+                source: nginx-ingress-controller
+          nginx.yaml: |- # nginx integration on the nginx-ingress-controller
+            ad_identifiers:
+              - controller
+            init_config:
+            instances:
+              - nginx_status_url: http://%%host%%:18080/nginx_status
+    clusterAgent:
+      extraConfd:
+        configDataMap:
+          postgres.yaml: |- # Postgres cluster check for DBM
+            cluster_check: true
+            init_config:
+            instances:
+              - dbm: true
+                host: postgres
+                port: 5432
+                username: ENC[k8s_secret@default/storedog-secrets/POSTGRES_INTEGRATION_USER]
+                password: ENC[k8s_secret@default/storedog-secrets/POSTGRES_INTEGRATION_PASSWORD]
+                tags:
+                  - env:${DD_ENV}
+                  - service:store-db
+                relations:
+                  - relation_name: advertisement
+                  - relation_name: discount
+                  - relation_name: items
+                  - relation_name: preorder_items
+                  - relation_name: influencer
+                query_samples:
+                  enabled: true
+                  explain_parameterized_queries: true
+                max_relations: 400
+                collect_function_metrics: true
+                collection_interval: 1
+                collect_schemas:
+                  enabled: true
+                collect_settings:
+                  enabled: true
+              - dbm: true
+                host: postgres
+                port: 5432
+                username: ENC[k8s_secret@default/storedog-secrets/POSTGRES_INTEGRATION_USER]
+                password: ENC[k8s_secret@default/storedog-secrets/POSTGRES_INTEGRATION_PASSWORD]
+                dbname: storedog_db
+                relations:
+                  - relation_regex: spree_.*
+                query_samples:
+                  enabled: true
+                  explain_parameterized_queries: true
+                max_relations: 400
+                collect_function_metrics: true
+                collection_interval: 1
+                collect_schemas:
+                  enabled: true
+                collect_settings:
+                  enabled: true

--- a/services/dbm/k8s-manifests/fake-traffic/dbm-env-configmap.yaml
+++ b/services/dbm/k8s-manifests/fake-traffic/dbm-env-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dbm-env
+  namespace: fake-traffic
+data:
+  FAKETRAFFIC_POSTGRES_HOST: postgres.default.svc.cluster.local

--- a/services/dbm/k8s-manifests/fake-traffic/dbm-query-one-cronjob.yaml
+++ b/services/dbm/k8s-manifests/fake-traffic/dbm-query-one-cronjob.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dbm-query-one
+  namespace: fake-traffic
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            ad.datadoghq.com/dbm-query-one.logs: '[{"source": "postgresql", "service": "cronjob"}]'
+        spec:
+          containers:
+          - name: dbm-query-one
+            image: ${REGISTRY_URL}/postgres:${SD_TAG}
+            command: ["/bin/sh", "/scripts/dbm_query_one.sh"]
+            envFrom:
+              - configMapRef:
+                  name: storedog-config
+              - configMapRef:
+                  name: dbm-env
+              - secretRef:
+                  name: storedog-secrets
+            volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          restartPolicy: OnFailure
+          volumes:
+          - name: scripts
+            configMap:
+              name: dbm-scripts
+              defaultMode: 0755

--- a/services/dbm/k8s-manifests/fake-traffic/dbm-query-two-cronjob.yaml
+++ b/services/dbm/k8s-manifests/fake-traffic/dbm-query-two-cronjob.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dbm-query-two
+  namespace: fake-traffic
+spec:
+  schedule: "*/2 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            ad.datadoghq.com/dbm-query-two.logs: '[{"source": "postgresql", "service": "cronjob"}]'
+        spec:
+          containers:
+          - name: dbm-query-two
+            image: ${REGISTRY_URL}/postgres:${SD_TAG}
+            command: ["/bin/sh", "/scripts/dbm_query_two.sh"]
+            envFrom:
+              - configMapRef:
+                  name: storedog-config
+              - configMapRef:
+                  name: dbm-env
+              - secretRef:
+                  name: storedog-secrets
+            volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          restartPolicy: OnFailure
+          volumes:
+          - name: scripts
+            configMap:
+              name: dbm-scripts
+              defaultMode: 0755

--- a/services/dbm/k8s-manifests/fake-traffic/dbm-scripts-configmap.yaml
+++ b/services/dbm/k8s-manifests/fake-traffic/dbm-scripts-configmap.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dbm-scripts
+  namespace: fake-traffic
+data:
+  dbm_query_one.sh: |
+    #!/bin/sh
+    set -f
+    QUERY="BEGIN; LOCK TABLE items IN EXCLUSIVE MODE;"
+    UPDATE_QUERY=$(cat <<EOF
+      UPDATE items 
+      SET order_count = order_count::int + 1
+      WHERE id = (SELECT id FROM items WHERE order_count::int > random() * 7000 LIMIT 1);
+      SELECT pg_sleep(1);
+    EOF
+    )
+    for i in {1..15}
+    do
+      for j in {1..20}
+      do
+        QUERY="$QUERY$UPDATE_QUERY"
+      done
+      QUERY="$QUERY COMMIT;"
+      PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d postgres -h "$FAKETRAFFIC_POSTGRES_HOST" -c "$QUERY"
+      QUERY="BEGIN; LOCK TABLE items IN EXCLUSIVE MODE;" # Reset for next iteration
+    done
+  dbm_query_two.sh: |
+    #!/bin/sh
+    set -f
+    QUERY="BEGIN; LOCK TABLE items IN EXCLUSIVE MODE;"
+    UPDATE_QUERY=$(cat <<EOF
+    UPDATE items
+    SET order_count = floor(random() * 7000), last_hour = CURRENT_TIMESTAMP
+    WHERE id = (SELECT id FROM items WHERE order_count::int > random() * 7000 ORDER BY RANDOM() LIMIT 1);
+    EOF
+    )
+    for i in {1..15}
+    do
+      for j in {1..20}
+      do
+        QUERY="$QUERY$UPDATE_QUERY"
+      done
+      QUERY="$QUERY COMMIT;"
+      PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d postgres -h "$FAKETRAFFIC_POSTGRES_HOST" -c "$QUERY"
+      QUERY="BEGIN; LOCK TABLE items IN EXCLUSIVE MODE;" # Reset for next iteration
+    done

--- a/services/dbm/k8s-manifests/storedog-app/configmaps/feature-flags-config.yaml
+++ b/services/dbm/k8s-manifests/storedog-app/configmaps/feature-flags-config.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags-config
+  namespace: default
+  labels:
+    app: frontend
+    managed-by: storedog
+    purpose: feature-flags
+    environment: development
+    tier: application
+data:
+  featureFlags.config.json: |
+    [
+      {
+        "id": "1",
+        "name": "dbm",
+        "active": true
+      },
+      {
+        "id": "2",
+        "name": "error-tracking",
+        "active": false
+      },
+      {
+        "id": "3",
+        "name": "api-errors",
+        "active": false
+      },
+      {
+        "id": "4",
+        "name": "product-card-frustration",
+        "active": false
+      }
+    ] 

--- a/services/dbm/k8s-manifests/storedog-app/deployments/dbm.yaml
+++ b/services/dbm/k8s-manifests/storedog-app/deployments/dbm.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbm
+spec:
+  ports:
+    - port: 7595
+      targetPort: 7595
+      name: http
+  selector:
+    app: dbm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dbm
+  template:
+    metadata:
+      labels:
+        app: dbm
+      annotations:
+        ad.datadoghq.com/dbm.logs: '[{"source": "python"}]'
+    spec:
+      volumes:
+        - name: app-volume
+          emptyDir: {}
+        - name: apmsocketpath
+          hostPath:
+            path: /var/run/datadog/
+      initContainers:
+        - name: wait-for-db
+          image: busybox
+          command: ['sh', '-c', 'until nc -z postgres 5432; do echo waiting for postgres; sleep 2; done;']
+      containers:
+        - name: dbm
+          image: ${REGISTRY_URL}/dbm:${SD_TAG}
+          ports:
+            - containerPort: 7595
+          env:
+            - name: FLASK_APP
+              value: "dbm.py"
+            - name: FLASK_DEBUG
+              value: "0"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: storedog-secrets
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: storedog-config
+                  key: POSTGRES_USER
+            - name: POSTGRES_HOST
+              value: postgres
+            - name: DD_ENV
+              value: ${DD_ENV}
+            - name: DD_SERVICE
+              value: storedog-dbm
+            - name: DD_VERSION
+              value: ${DD_VERSION_DBM}
+            - name: DD_DBM_PROPAGATION_MODE
+              value: full
+            - name: DD_LOGS_INJECTION
+              value: "true"
+            - name: DD_PROFILING_ENABLED
+              value: "true"
+            - name: DD_APPSEC_ENABLED
+              value: "true"
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+          volumeMounts:
+            - name: apmsocketpath
+              mountPath: /var/run/datadog

--- a/services/dbm/k8s-manifests/storedog-app/secrets/shared-secrets.yaml
+++ b/services/dbm/k8s-manifests/storedog-app/secrets/shared-secrets.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storedog-secrets
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: postgres  # Change this in production
+  DB_PASSWORD: postgres       # Change this in production
+  POSTGRES_INTEGRATION_USER: datadog  # For Datadog integration
+  POSTGRES_INTEGRATION_PASSWORD: datadog  # For Datadog integration

--- a/services/dbm/k8s-manifests/storedog-app/statefulsets/postgres.yaml
+++ b/services/dbm/k8s-manifests/storedog-app/statefulsets/postgres.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  ports:
+    - port: 5432
+      name: postgres
+  clusterIP: None
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    tags.datadoghq.com/env: ${DD_ENV}
+    tags.datadoghq.com/service: store-db
+    tags.datadoghq.com/version: "15.0"
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/service: store-db
+        tags.datadoghq.com/version: "15.0"
+      annotations:
+        ad.datadoghq.com/postgres.logs: |
+          [{
+            "source": "postgresql",
+            "service": "store-db",
+            "auto_multi_line_detection": true,
+            "path": "/var/log/pg_log_shared/postgresql-*.json",
+            "type": "file"
+          }]
+    spec:
+      containers:
+        - name: postgres
+          image: ${REGISTRY_URL}/postgres:${SD_TAG}
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: trust
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: storedog-config
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: storedog-secrets
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+            - name: shared-pg-logs
+              mountPath: /var/log/pg_log
+      volumes:
+        - name: shared-pg-logs
+          persistentVolumeClaim:
+            claimName: shared-pg-logs
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 10Gi

--- a/services/dbm/scripts/dbm_query_one.sh
+++ b/services/dbm/scripts/dbm_query_one.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+
+# disable path expansion so we can use a literal *
+set -f
+QUERY="LOCK TABLE items IN EXCLUSIVE MODE;"
+UPDATE_QUERY=$(cat <<EOF
+  UPDATE items 
+  SET order_count = order_count::int + 1
+  WHERE id = (SELECT id FROM items WHERE order_count::int > random() * 7000 LIMIT 1);
+  SELECT pg_sleep(1);
+EOF
+)
+
+# Loop for running the query
+for i in {1..15
+do
+  # Loop for building the query
+  for j in {1..20}
+  do
+    QUERY+="${UPDATE_QUERY}"
+  done
+  psql -U postgres -d postgres -h postgres -c "$QUERY"
+done

--- a/services/dbm/scripts/dbm_query_one.sh
+++ b/services/dbm/scripts/dbm_query_one.sh
@@ -12,7 +12,7 @@ EOF
 )
 
 # Loop for running the query
-for i in {1..15
+for i in {1..15}
 do
   # Loop for building the query
   for j in {1..20}

--- a/services/dbm/scripts/dbm_query_two.sh
+++ b/services/dbm/scripts/dbm_query_two.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+# disable path expansion so we can use a literal *
+set -f
+QUERY="LOCK TABLE items IN EXCLUSIVE MODE;"
+UPDATE_QUERY=$(cat <<EOF
+UPDATE items
+SET order_count = floor(random() * 7000), last_hour = CURRENT_TIMESTAMP
+WHERE id = (SELECT id FROM items WHERE order_count::int > random() * 7000 ORDER BY RANDOM() LIMIT 1);
+EOF
+)
+
+# Loop for running the query
+for i in {1..15}
+do
+  # Loop for building the query
+  for j in {1..20}
+  do
+    QUERY+="${UPDATE_QUERY}"
+  done
+  psql -U postgres -d postgres -h localhost -c "$QUERY"
+done


### PR DESCRIPTION
## Description
> [!IMPORTANT]
> These changes are based on branch `services-trace-library-updates`.

Creates k8s-manifest files needed to run the `dbm` service and configuration needed for Datadog Database monitoring.

## How to test
K8s testing steps are outline in the k8s-manifests/readme. It's important to note that unlike Docker compose, K8s won't build container images. Images must be pre-built and hosted in a registry. For development, you can run a local registry. Then build and push images. The images must be built and pushed on the `worker` node as that is where the services will run and look for `localhost`.

The [development K8s Sandbox](https://learn.datadoghq.com/courses/take/sandbox-k8s-testing/texts/64160521-dev-testing-and-troubleshooting-kubernetes-images) is currently set to test. The services files from `main` branch are used to build and push to the local registry. You can also set the registry url to the live public version. Follow the steps in the readme to setup the Datadog operator and start Storedog.

Use the **Storedog** tab to the right of the `worker` tabs to load the site. Again, the pods are running on the worker node.

Review the dbm/k8s-manifests/readme for steps to merge these files into the standard k8s-manifest folder for testing.


