### PR TITLE
K8s move puppeteer service to fake-traffic namespace

### DIFF
--- a/k8s-manifests/README.md
+++ b/k8s-manifests/README.md
@@ -223,7 +223,7 @@ for file in k8s-manifests/storedog-app/**/*.yaml; do envsubst < "$file" | kubect
 
 5. **Deploy Puppeteer:**
 
-This command creates a `fake-traffic` namespace.
+The following command creates a `fake-traffic` namespace.
 
 ```bash
 kubectl create namespace fake-traffic
@@ -234,7 +234,7 @@ kubectl create namespace fake-traffic
 > [!IMPORTANT]
 > If you're using a namespace other than `storedog`, you must edit the `STOREDOG_URL` in `puppeteer.yaml`.
 
-This command sets variables and deploys Puppeteer.
+The following command sets variables and deploys Puppeteer.
 
 ```bash
 envsubst < k8s-manifests/fake-traffic/puppeteer.yaml | kubectl apply -f -

--- a/k8s-manifests/README.md
+++ b/k8s-manifests/README.md
@@ -165,7 +165,7 @@ kubectl create secret generic datadog-secret \
   --from-literal app-key=$DD_APP_KEY
 ```
 
-2. Apply the Datadog Agent definition:
+3. Apply the Datadog Agent definition:
 
 ```bash
 kubectl apply -f k8s-manifests/datadog/datadog-agent.yaml
@@ -205,7 +205,7 @@ kubectl create secret generic datadog-secret \
   -n storedog
 ```
 
-3. **Deploy the Storedog Application:**
+4. **Deploy the Storedog Application:**
 
 This command deploys all application components into it.
 
@@ -213,13 +213,13 @@ This command deploys all application components into it.
 for file in k8s-manifests/storedog-app/**/*.yaml; do envsubst < "$file" | kubectl apply -n storedog -f -; done
 ```
 
-4. **Apply manifest changes to one service:**
+   - **Apply manifest changes to one service:**
 
-While testing, you might change one manifest file. Rather than update all at once, you can apply the change like this.
+      While testing, you might change one manifest file. Rather than update all at once, you can apply the change like this.
 
-```bash
-envsubst < k8s-manifests/storedog-app/deployments/backend.yaml | kubectl apply -n storedog -f -
-```
+      ```bash
+      envsubst < k8s-manifests/storedog-app/deployments/backend.yaml | kubectl apply -n storedog -f -
+      ```
 
 5. **Deploy Puppeteer:**
 

--- a/k8s-manifests/README.md
+++ b/k8s-manifests/README.md
@@ -221,23 +221,41 @@ While testing, you might change one manifest file. Rather than update all at onc
 envsubst < k8s-manifests/storedog-app/deployments/backend.yaml | kubectl apply -n storedog -f -
 ```
 
-5. **To reset the all Storedog:**
+5. **Deploy Puppeteer:**
 
-You only need to delete the application's namespace. The cluster components can remain installed.
+This command creates a `fake-traffic` namespace.
+
+```bash
+kubectl create namespace fake-traffic
+```
+
+6. **Deploy Puppeteer:**
+
+> [!IMPORTANT]
+> If you're using a namespace other than `storedog`, you must edit the `STOREDOG_URL` in `puppeteer.yaml`.
+
+This command sets variables and deploys Puppeteer.
+
+```bash
+envsubst < k8s-manifests/fake-traffic/puppeteer.yaml | kubectl apply -f -
+```
+
+## Troubleshooting
+
+- Reset the all Storedog:
+
+> [!NOTE]
+> You only need to delete the application's namespace. The cluster components can remain installed.
 
 ```bash
 kubectl delete namespace storedog
 ```
 
-6. **To restart one service:**
-
-After rebuilding a container image, it's faster to restart only the service you need.
+- Restart one service:
 
 ```bash
-kubectl rollout restart deployment backend -n storedog
+kubectl rollout restart deployment -n storedog ads
 ```
-
-## Troubleshooting
 
 - Check pod status in the namespace:
 

--- a/k8s-manifests/fake-traffic/puppeteer.yaml
+++ b/k8s-manifests/fake-traffic/puppeteer.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: puppeteer
+  namespace: fake-traffic
 spec:
   replicas: 1
   selector:

--- a/k8s-manifests/fake-traffic/puppeteer.yaml
+++ b/k8s-manifests/fake-traffic/puppeteer.yaml
@@ -18,7 +18,8 @@ spec:
           image: ${REGISTRY_URL}/puppeteer:${SD_TAG}
           env:
             - name: STOREDOG_URL
-              value: "http://service-proxy"
+              # Change namespace as needed
+              value: "http://service-proxy.storedog.svc.cluster.local"
             - name: PUPPETEER_TIMEOUT
               value: "30000"
             - name: SKIP_SESSION_CLOSE


### PR DESCRIPTION
## Description
Previously Puppeteer ran in the same namespace as Storedog (usually `storedog`). This moved the puppeteer definition to a new folder and sets the namespace as `fake-traffic`.

## How to test
K8s testing steps are outline in the k8s-manifests/readme. It's important to note that unlike Docker compose, K8s won't build container images. Images must be pre-built and hosted in a registry. For development, you can run a local registry. Then build and push images. The images must be built and pushed on the `worker` node as that is where the services will run and look for `localhost`.

The [development K8s Sandbox](https://learn.datadoghq.com/courses/take/sandbox-k8s-testing/texts/64160521-dev-testing-and-troubleshooting-kubernetes-images) is currently set to test. The services files from `main` branch are used to build and push to the local registry. You can also set the registry url to the live public version. Follow the steps in the readme to setup the Datadog operator and start Storedog.

Use the **Storedog** tab to the right of the `worker` tabs to load the site. Again, the pods are running on the worker node.

Once storedog is running, check pods in `fake-traffic` to confirm the pod is running:
```
kubectl get pods -n fake-traffic
```
View traffic in the trial account and confirm data is recieved.


