### PR TITLE
Update flask version

### DIFF
--- a/services/ads/python/requirements.txt
+++ b/services/ads/python/requirements.txt
@@ -2,7 +2,7 @@ certifi==2020.11.8
 chardet==3.0.4
 click==7.1.2
 ddtrace==3.10.1
-Flask==1.1.2
+Flask==1.1.4
 Flask-Cors==3.0.10
 Flask-SQLAlchemy==2.4.4
 idna==2.10

--- a/services/discounts/requirements.txt
+++ b/services/discounts/requirements.txt
@@ -2,7 +2,7 @@ certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2
 ddtrace==3.10.1
-Flask==1.1.2
+Flask==1.1.4
 Flask-Cors==3.0.10
 Flask-SQLAlchemy==2.4.4
 idna==2.10


### PR DESCRIPTION
## Description
This is a minor update to flask to bring it to a supported version for single step instrumentation.

Note: The latest version of Flask is 3.1.1. It would be good to update to a newer version eventually. That will take much more time to update dependencies and code. This minor bump brings Discounts and Ads-python services to a minimum requirement for SSI without needing additional changes.

## How to test
clone the repo
checkout this branch
Uncomment `ads-pythong` from `docker-compose.dev.yml`
Set `ADS_B_PERCENT=50` under service-proxy
run `docker compose -f docker-compose.dev.yml up -d`
This will build and run all services.
Verify trace data from discounts and ads-python

