### PR TITLE
updated docker python image version

### DIFF
--- a/services/ads/python/Dockerfile
+++ b/services/ads/python/Dockerfile
@@ -2,7 +2,7 @@
 # ^ This enables the new BuildKit stable syntax which can be
 # run with the DOCKER_BUILDKIT=1 environment variable in your
 # docker build command (see build.sh)
-FROM python:3.9.6-slim-buster
+FROM python:3.9.23-slim-bookworm
 # Update, upgrade, and cleanup debian packages
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \

--- a/services/dbm/Dockerfile
+++ b/services/dbm/Dockerfile
@@ -2,7 +2,7 @@
 # ^ This enables the new BuildKit stable syntax which can be
 # run with the DOCKER_BUILDKIT=1 environment variable in your
 # docker build command (see build.sh)
-FROM python:3.9.6-slim-buster
+FROM python:3.9.23-slim-bookworm
 
 # Update, upgrade, and cleanup debian packages
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/services/discounts/Dockerfile
+++ b/services/discounts/Dockerfile
@@ -2,7 +2,7 @@
 # ^ This enables the new BuildKit stable syntax which can be
 # run with the DOCKER_BUILDKIT=1 environment variable in your
 # docker build command (see build.sh)
-FROM python:3.9.6-slim-buster
+FROM python:3.9.23-slim-bookworm
 
 # Update, upgrade, and cleanup debian packages
 RUN export DEBIAN_FRONTEND=noninteractive && \


### PR DESCRIPTION
## Description
This updates the Docker image used to build Python services from `python:3.9.6-slim-buster` to `python:3.9.23-slim-bookworm`. This resolves an issue while building related to the security repo being removed for [unsupported versions of Debian](https://serverfault.com/questions/1074688/security-debian-org-does-not-have-a-release-file-on-with-debian-docker-images).

So far only the DBM build fails because it upgrades all packages. Updating all Python services now may help prevent issues in the future.

## How to test
clone the repo
checkout this branch
Add DBM to `docker-compose.dev.yml`
run `docker compose -f docker-compose.dev.yml up -d`
This will build and run all services.
Confirm data in trial account.


