### PR TITLE
Move ads-python from docker-compose to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,38 @@ Run two Ads services and split traffic between them. The amount of traffic sent 
 
 **How to use**
 1. Add a second Ads service to the `docker-compose.yml`
+
+    ```yaml
+      # OPTIONAL: Advertisement service (Python)
+      ads-python:
+        image: ghcr.io/datadog/storedog/ads:${STOREDOG_IMAGE_VERSION:-latest}
+        build:
+          context: ./services/ads/python
+        depends_on:
+          - postgres
+          - dd-agent
+        environment:
+          - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+          - POSTGRES_USER=${POSTGRES_USER:-postgres}
+          - POSTGRES_HOST=postgres
+          - DD_AGENT_HOST=dd-agent
+          - DD_SERVICE=store-ads-python
+          - DD_VERSION=${DD_VERSION_ADS_PYTHON:-1.0.0}
+        networks:
+          - storedog-network
+        labels:
+          com.datadoghq.ad.logs: '[{"source": "python"}]'
+    ```
+
 1. Add and set these environment variables to the `service-proxy` service:
+
+    ```yaml
+    environment:
+      - ADS_A_UPSTREAM=${ADS_A_UPSTREAM:-ads:3030}
+      - ADS_B_UPSTREAM=${ADS_B_UPSTREAM:-ads-python:3030}
+      - ADS_B_PERCENT=${ADS_B_PERCENT:-0}
+    ```
+
     - `ADS_A_UPSTREAM`: Host and port for the primary (A) ads service (default: `ads:3030`)
     - `ADS_B_UPSTREAM`: Host and port for the secondary (B) ads service (default: `ads-python:3030`)
     - `ADS_B_PERCENT`: Percentage of traffic to route to the B (Python) ads service (default: `0`). The remainder goes to the A (Java) ads service.

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Run two Ads services and split traffic between them. The amount of traffic sent 
     - `ADS_B_UPSTREAM`: Host and port for the secondary (B) ads service (default: `ads-python:3030`)
     - `ADS_B_PERCENT`: Percentage of traffic to route to the B (Python) ads service (default: `0`). The remainder goes to the A (Java) ads service.
       - Set to a value between `0` and `100` to control the split.
-1. Start the app via `docker compose up`
+1. Start the app via `docker compose up -d`
 
 ### Feature flags
 Some capabilities are hidden behind feature flags, which can be controlled via `services/frontend/site/featureFlags.config.json`. 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -183,25 +183,6 @@ services:
     labels:
       com.datadoghq.ad.logs: '[{"source": "java"}]'
 
-  # OPTIONAL: Advertisement service (Python)
-  # ads-python:
-  #   build:
-  #     context: ./services/ads/python
-  #   depends_on:
-  #     - postgres
-  #     - dd-agent
-  #   environment:
-  #     - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-  #     - POSTGRES_USER=${POSTGRES_USER:-postgres}
-  #     - POSTGRES_HOST=postgres
-  #     - DD_AGENT_HOST=dd-agent
-  #     - DD_SERVICE=store-ads-python
-  #     - DD_VERSION=${DD_VERSION_ADS_PYTHON:-1.0.0}
-  #   networks:
-  #     - storedog-network
-  #   labels:
-  #     com.datadoghq.ad.logs: '[{"source": "python"}]'
-
   # Web server and reverse proxy
   service-proxy:
     build:
@@ -215,9 +196,6 @@ services:
       - frontend
       - dd-agent
     environment:
-      - ADS_A_UPSTREAM=${ADS_A_UPSTREAM:-ads:3030} # Only needed if using AB testing
-      - ADS_B_UPSTREAM=${ADS_B_UPSTREAM:-ads-python:3030} # Only needed if using AB testing
-      - ADS_B_PERCENT=${ADS_B_PERCENT:-0} # Percent of traffic to ads-python; remainder goes to ads-java. Only needed if using AB testing
       - DD_AGENT_HOST=dd-agent
       - DD_SERVICE=service-proxy
       - DD_VERSION=${DD_VERSION_NGINX:-1.28.0}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,22 +129,6 @@ services:
       com.datadoghq.ad.logs: '[{"source": "java"}]'
       com.datadoghq.tags.service: 'store-ads'
       com.datadoghq.tags.version: '${DD_VERSION_ADS:-1.0.0}'
-  # ads-python:
-  #   image: ghcr.io/datadog/storedog/ads:${STOREDOG_IMAGE_VERSION:-latest}
-  #   depends_on:
-  #     - postgres
-  #     - dd-agent
-  #   environment:
-  #     - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-  #     - POSTGRES_USER=${POSTGRES_USER:-postgres}
-  #     - POSTGRES_HOST=postgres
-  #     - DD_AGENT_HOST=dd-agent
-  #     - DD_SERVICE=store-ads-python
-  #     - DD_VERSION=${DD_VERSION_ADS_PYTHON:-1.0.0}
-  #   networks:
-  #     - storedog-network
-  #   labels:
-  #     com.datadoghq.ad.logs: '[{"source": "python"}]'
   service-proxy:
     image: ghcr.io/datadog/storedog/nginx:${STOREDOG_IMAGE_VERSION:-latest}
     restart: always
@@ -156,9 +140,6 @@ services:
       - frontend
       - dd-agent
     environment:
-      - ADS_A_UPSTREAM=${ADS_A_UPSTREAM:-ads:3030} # Only needed if using AB testing
-      - ADS_B_UPSTREAM=${ADS_B_UPSTREAM:-ads-python:3030} # Only needed if using AB testing
-      - ADS_B_PERCENT=${ADS_B_PERCENT:-0} # Percent of traffic to ads-python; remainder goes to ads-java. Only needed if using AB testing
       - DD_AGENT_HOST=dd-agent
       - DD_SERVICE=service-proxy
       - DD_VERSION=${DD_VERSION_NGINX:-1.28.0}


### PR DESCRIPTION
## Description
Moved the settings needed for ads AB testing feature from `docker-compose*.yml` files to readme. These are only needed when using the feature so don't need to always be in the compose files.

## How to test
no testing needed


