### PR TITLE
reduced sidekiq concurrency and increased pod resource limits

### DIFF
--- a/k8s-manifests/storedog-app/deployments/worker.yaml
+++ b/k8s-manifests/storedog-app/deployments/worker.yaml
@@ -85,8 +85,8 @@ spec:
               memory: "512Mi"
               cpu: "250m"
             limits:
-              memory: "1Gi"
-              cpu: "500m"
+              memory: "2Gi"
+              cpu: "1000m"
           volumeMounts:
             - name: apmsocketpath
               mountPath: /var/run/datadog

--- a/services/backend/config/sidekiq.yml
+++ b/services/backend/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:concurrency: 5
+:concurrency: 2
 :max_memory: 512 # MB
 :gc_interval: 10 # GC every 10 jobs
 :queues:


### PR DESCRIPTION
## Description
When running in K8s, the pod will spike cpu and memory use that will trigger a pod restart. A link to this issue appears in the logs: [RTT warning can signal CPU saturation · sidekiq sidekiq · Discussion #5039](https://github.com/sidekiq/sidekiq/discussions/5039) 

The worker service has a concurrency setting in config/sidekiq.yml set to 5. Despite being lower than the default of 10, the pod will restart.

I found that setting concurrency to 2 and increasing the pod resource limits avoids regular restarts. The cpu and memory still spike but aren’t enough to trigger a restart.

## How to test

K8s testing steps are outline in the k8s-manifests/readme. It's important to note that unlike Docker compose, K8s won't build container images. Images must be pre-built and hosted in a registry. For development, you can run a local registry. Then build and push images. The images must be built and pushed on the `worker` node as that is where the services will run and look for `localhost`.

The [development K8s Sandbox](https://learn.datadoghq.com/courses/take/sandbox-k8s-testing/texts/64160521-dev-testing-and-troubleshooting-kubernetes-images) is currently set to test.

On the worker terminal: cd to `root/lab/storedog`
checkout this branch (git clone runs during track setup)
Run the build command in the k8s readme

On the control-plane terminal: cd to `root/lab/storedog`
checkout this branch (git clone runs during track setup)
Follow the steps in the readme to setup the Datadog operator and start Storedog.

Watch the pods run: `watch kubectl get pods -n storedog`
Previously, the worker pod would restart about every 3 minutes. Wait at least 10 minutes. I've let it run for a full hour to confirm.

