### PR TITLE
set frontend to prod and reduced delay in probed

### DIFF
--- a/k8s-manifests/storedog-app/deployments/frontend.yaml
+++ b/k8s-manifests/storedog-app/deployments/frontend.yaml
@@ -42,7 +42,7 @@ spec:
           image: ${REGISTRY_URL}/frontend:${SD_TAG}
           ports:
             - containerPort: 3000
-          command: ["npm", "run", "dev"]
+          command: ["npm", "run", "prod"]
           env:
             - name: NEXT_PUBLIC_ADS_ROUTE
               valueFrom:
@@ -126,12 +126,13 @@ spec:
             httpGet:
               path: /
               port: 3000
-            initialDelaySeconds: 180
-            periodSeconds: 20
+            initialDelaySeconds: 40
+            periodSeconds: 30
             failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /
               port: 3000
-            initialDelaySeconds: 120
+            initialDelaySeconds: 30
             periodSeconds: 20
+            timeoutSeconds: 5


### PR DESCRIPTION
## Description
The frontend service takes over 100 seconds to become ready when started.

This time can be improved by adjusting timing of readiness and liveness probes.

The services is also set to use the dev version. The dev version has a shorter start time than prod but the prod version is faster once running.

## How to test

K8s testing steps are outline in the k8s-manifests/readme. It's important to note that unlike Docker compose, K8s won't build container images. Images must be pre-built and hosted in a registry. For development, you can run a local registry. Then build and push images. The images must be built and pushed on the `worker` node as that is where the services will run and look for `localhost`.

The [development K8s Sandbox](https://learn.datadoghq.com/courses/take/sandbox-k8s-testing/texts/64160521-dev-testing-and-troubleshooting-kubernetes-images) is currently set to test.

On the worker terminal: cd to `root/lab/storedog`
checkout this branch (git clone runs during track setup)
Run the build command in the k8s readme

On the control-plane terminal: cd to `root/lab/storedog`
checkout this branch (git clone runs during track setup)
Follow the steps in the readme to setup the Datadog operator and start Storedog.

Watch the pods run: `watch kubectl get pods -n storedog`
The frontend service should take around 80s to become `ready`
Use the **Storedog** tab to the right of "worker" tabs to view Storedog and confirm it's running as expected.


