### PR TITLE
updated sass version

### DIFF
--- a/services/backend/Gemfile
+++ b/services/backend/Gemfile
@@ -87,8 +87,8 @@ gem 'activerecord-nulldb-adapter'
 # improved JSON rendering performance
 gem 'oj'
 
-# Fix SCSS errors with Ruby 3 on MacOS
-gem 'sassc', github: 'sass/sassc-ruby', group: :development
+gem 'sassc-rails', '~> 2.1.2'
+gem 'sass', '~> 3.7.4'  # Dart Sass implementation
 
 # Required for Ruby 3.1.7
 gem 'net-smtp'


### PR DESCRIPTION
## Description
There’s an intermittent segmentation fault that occurs in the worker service.

```
/bundle/bundler/gems/sassc-ruby-4fce2b635ca5/lib/sassc/engine.rb:43: [BUG] Segmentation fault at 0x0000000000000000
```

## How to test
K8s testing steps are outline in the k8s-manifests/readme. It's important to note that unlike Docker compose, K8s won't build container images. Images must be pre-built and hosted in a registry. For development, you can run a local registry. Then build and push images. The images must be built and pushed on the `worker` node as that is where the services will run and look for `localhost`.

The [development K8s Sandbox](https://learn.datadoghq.com/courses/take/sandbox-k8s-testing/texts/64160521-dev-testing-and-troubleshooting-kubernetes-images) is currently set to test.

On the worker terminal: cd to `root/lab/storedog`
checkout this branch (git clone runs during track setup)
Run the build command in the k8s readme

On the control-plane terminal: cd to `root/lab/storedog`
checkout this branch (git clone runs during track setup)
Follow the steps in the readme to setup the Datadog operator and start Storedog.

Watch the pods run: `watch kubectl get pods -n storedog` on 1 terminal
In a second terminal run this command. This previously crashed the pod.

```
kubectl exec -it <worker_pod> -n storedog -- bundle exec rails assets:precompile
```

