### PR TITLE
Upgrade RubyGem and Bundler

### DIFF
--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -49,6 +49,9 @@ ENV PATH="${BUNDLE_BIN}:${PATH}"
 COPY . .
 
 # Upgrade RubyGems and Bundler
+# When upgrading RubyGems
+#  * upgrade Bundler to match the new RubyGems version
+#  * update "BUNDLED WITH" in Gemfile.lock to match the bundler version
 RUN gem update --system 3.5.23
 RUN gem install bundler -v 2.5.23
 

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -48,6 +48,10 @@ ENV PATH="${BUNDLE_BIN}:${PATH}"
 
 COPY . .
 
+# Upgrade RubyGems and Bundler
+RUN gem update --system 3.5.23
+RUN gem install bundler -v 2.5.23
+
 RUN bundle install || exit 1
 RUN npm install
 RUN npm run build

--- a/services/backend/Gemfile.lock
+++ b/services/backend/Gemfile.lock
@@ -734,4 +734,4 @@ RUBY VERSION
    ruby 3.1.7
 
 BUNDLED WITH
-   2.3.27
+   2.5.23


### PR DESCRIPTION
## Description
This updates the versions of RubyGem and Bundler to meet upcoming minimum requirements for SSI and Profiler features.

Updated versions:
- gem: 3.5.23
- bundler: 2.5.23

## How to test
clone repo and checkout this branch
run this command to build containers and run Storedog
```bash
docker compose -f docker-compose.dev.yml up -d
```
After Storedog is running, check the version of `gem` and `bundler`
```bash
docker compose exec backend gem --version
docker compose exec backend bundle --version
```
Confirm the versions

