### PR TITLE
[Feature] Optimize Storedog Startup Time

### DIFF
--- a/k8s-manifests/storedog-app/deployments/ads.yaml
+++ b/k8s-manifests/storedog-app/deployments/ads.yaml
@@ -62,3 +62,27 @@ spec:
           volumeMounts:
             - name: apmsocketpath
               mountPath: /var/run/datadog
+          # Health probes optimized for Java Spring Boot application
+          startupProbe:
+            tcpSocket:
+              port: 3030
+            initialDelaySeconds: 15      # Allow for JVM + Spring Boot startup
+            periodSeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 5          # 15s + (5 × 3s) = 30s max startup
+            successThreshold: 1
+          readinessProbe:
+            tcpSocket:
+              port: 3030
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 2
+            successThreshold: 1
+          livenessProbe:
+            tcpSocket:
+              port: 3030
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/k8s-manifests/storedog-app/deployments/backend.yaml
+++ b/k8s-manifests/storedog-app/deployments/backend.yaml
@@ -34,6 +34,9 @@ spec:
         - name: wait-for-db
           image: busybox
           command: ['sh', '-c', 'until nc -z postgres 5432; do echo waiting for postgres; sleep 2; done;']
+        - name: wait-for-redis
+          image: busybox
+          command: ['sh', '-c', 'until nc -z redis 6379; do echo waiting for redis; sleep 2; done;']
       containers:
         - name: backend
           image: ${REGISTRY_URL}/backend:${SD_TAG}
@@ -106,3 +109,27 @@ spec:
           volumeMounts:
             - name: apmsocketpath
               mountPath: /var/run/datadog
+          # Health probes optimized for Rails application
+          startupProbe:
+            tcpSocket:
+              port: 4000
+            initialDelaySeconds: 3       # Very fast with init containers
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 5          # 3s + (5 × 2s) = 13s max startup
+            successThreshold: 1
+          readinessProbe:
+            tcpSocket:
+              port: 4000
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 2             # Fast for API service
+            timeoutSeconds: 1
+            failureThreshold: 2
+            successThreshold: 1
+          livenessProbe:
+            tcpSocket:
+              port: 4000
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 10            # Frequent for critical service
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/k8s-manifests/storedog-app/deployments/discounts.yaml
+++ b/k8s-manifests/storedog-app/deployments/discounts.yaml
@@ -84,3 +84,27 @@ spec:
           volumeMounts:
             - name: apmsocketpath
               mountPath: /var/run/datadog
+          # Health probes optimized for Python Flask application
+          startupProbe:
+            tcpSocket:
+              port: 2814
+            initialDelaySeconds: 2       # Very fast Flask startup with DB ready
+            periodSeconds: 1
+            timeoutSeconds: 1
+            failureThreshold: 6          # 2s + (6 × 1s) = 8s max startup
+            successThreshold: 1
+          readinessProbe:
+            tcpSocket:
+              port: 2814
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 1             # Ultra-fast for microservice
+            timeoutSeconds: 1
+            failureThreshold: 2
+            successThreshold: 1
+          livenessProbe:
+            tcpSocket:
+              port: 2814
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/k8s-manifests/storedog-app/deployments/frontend.yaml
+++ b/k8s-manifests/storedog-app/deployments/frontend.yaml
@@ -116,23 +116,34 @@ spec:
               cpu: "100m"
             limits:
               memory: "2Gi"
+              cpu: "500m"
           volumeMounts:
             - name: apmsocketpath
               mountPath: /var/run/datadog
             - name: feature-flags-config
               mountPath: /app/featureFlags.config.json
               subPath: featureFlags.config.json
-          livenessProbe:
-            httpGet:
-              path: /
+          # Health probes optimized for Next.js React application
+          startupProbe:
+            tcpSocket:
               port: 3000
-            initialDelaySeconds: 40
-            periodSeconds: 30
-            failureThreshold: 5
+            initialDelaySeconds: 3       # Very fast Next.js startup (no DB deps)
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 5          # 3s + (5 × 2s) = 13s max startup
+            successThreshold: 1
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 3000
-            initialDelaySeconds: 30
-            periodSeconds: 20
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 2             # Ultra-fast for frontend load balancer
+            timeoutSeconds: 1
+            failureThreshold: 2
+            successThreshold: 1
+          livenessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 10            # More frequent for user-facing frontend
             timeoutSeconds: 5
+            failureThreshold: 3

--- a/k8s-manifests/storedog-app/deployments/nginx.yaml
+++ b/k8s-manifests/storedog-app/deployments/nginx.yaml
@@ -8,6 +8,9 @@ spec:
     - port: 80
       targetPort: 80
       name: http
+    - port: 81
+      targetPort: 81
+      name: status
   selector:
     app: service-proxy
 ---
@@ -48,6 +51,9 @@ spec:
           image: ${REGISTRY_URL}/nginx:${SD_TAG}
           ports:
             - containerPort: 80
+              name: http
+            - containerPort: 81
+              name: status
           env:
             - name: NGINX_RESOLVER
               value: "kube-dns.kube-system.svc.cluster.local"
@@ -69,3 +75,33 @@ spec:
           volumeMounts:
             - name: apmsocketpath
               mountPath: /var/run/datadog
+          # Health probes optimized for Nginx reverse proxy
+          startupProbe:
+            httpGet:
+              path: /nginx_status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 2       # Nginx starts very fast
+            periodSeconds: 2
+            timeoutSeconds: 3            # Slightly more tolerant
+            failureThreshold: 5          # 2s + (5 × 2s) = 12s max startup
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /nginx_status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 3             # Very frequent for proxy service
+            timeoutSeconds: 2            # Fast for nginx status
+            failureThreshold: 2          # Quick failure detection for proxy
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /nginx_status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 10            # Conservative for production
+            timeoutSeconds: 5            # Allow for potential upstream delays
+            failureThreshold: 3          # Standard tolerance

--- a/k8s-manifests/storedog-app/deployments/worker.yaml
+++ b/k8s-manifests/storedog-app/deployments/worker.yaml
@@ -90,3 +90,36 @@ spec:
           volumeMounts:
             - name: apmsocketpath
               mountPath: /var/run/datadog
+          # Health probes optimized for background worker
+          startupProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - "ps aux | grep '[s]idekiq' | grep -v grep"
+            initialDelaySeconds: 8       # Fast worker startup with deps ready
+            periodSeconds: 3             # Quick checks for background process
+            timeoutSeconds: 3
+            failureThreshold: 6          # 8s + (6 × 3s) = 26s max startup
+            successThreshold: 1
+          readinessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - "ps aux | grep '[s]idekiq' | grep -v grep"
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 5             # More frequent monitoring
+            timeoutSeconds: 3
+            failureThreshold: 2          # Quick failure detection
+            successThreshold: 1
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - "ps aux | grep '[s]idekiq' | grep -v grep"
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 20            # More frequent for critical background worker
+            timeoutSeconds: 8
+            failureThreshold: 3          # Less tolerant for faster recovery

--- a/k8s-manifests/storedog-app/statefulsets/postgres.yaml
+++ b/k8s-manifests/storedog-app/statefulsets/postgres.yaml
@@ -63,6 +63,45 @@ spec:
               mountPath: /var/lib/postgresql/data
             - name: postgres-logs
               mountPath: /var/log/pg_log
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "$POSTGRES_USER" -d postgres -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 5       # Fast PostgreSQL startup
+            periodSeconds: 3
+            timeoutSeconds: 3
+            failureThreshold: 8          # 5s + (8 × 3s) = 29s max startup
+            successThreshold: 1
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "$POSTGRES_USER" -d postgres -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 3             # Faster checks for critical dependency
+            timeoutSeconds: 2
+            failureThreshold: 2          # Quick failure detection for load balancer
+            successThreshold: 1
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "$POSTGRES_USER" -d postgres -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 0       # Startup probe handles delay
+            periodSeconds: 20            # Slightly more frequent for fast DB
+            timeoutSeconds: 5            # Faster timeout for responsive DB
+            failureThreshold: 3          # Less tolerant since DB is fast
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
   volumeClaimTemplates:
     - metadata:
         name: postgres-data

--- a/k8s-manifests/storedog-app/statefulsets/redis.yaml
+++ b/k8s-manifests/storedog-app/statefulsets/redis.yaml
@@ -50,6 +50,36 @@ spec:
           volumeMounts:
             - name: redis-data
               mountPath: /data
+          # Health probes optimized for fast Redis startup
+          startupProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 2       # Redis starts in ~1-2s, minimal buffer for PV
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 8          # 2s + (8 × 2s) = 18s max startup
+            successThreshold: 1
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 0       # Startup handles delay
+            periodSeconds: 1             # Ultra-fast - Redis is critical dependency
+            timeoutSeconds: 1
+            failureThreshold: 2          # Fail fast if issues
+            successThreshold: 1
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 0       # Startup handles delay
+            periodSeconds: 20            # Moderate frequency for liveness
+            timeoutSeconds: 3
+            failureThreshold: 3
   volumeClaimTemplates:
     - metadata:
         name: redis-data


### PR DESCRIPTION
## Description

The overall intention of this PR is to improve the startup time of Storedog in a Kubernetes environment.

This pull request introduces health probes across multiple Kubernetes deployments and statefulsets to improve application monitoring and failure recovery. Additionally, it adds a new port to the Nginx service and updates resource limits for PostgreSQL. 

Below is a summary of the key changes grouped by theme.

### 🕐 Startup time comparison
============================

(Main branch) (Local) Time until Storedog is available: 150s
(This branch) (Local) Time until Storedog is available: 40s

### Health Probes for Improved Monitoring
* **Java Spring Boot (`ads.yaml`)**: Added `startupProbe`, `readinessProbe`, and `livenessProbe` using TCP socket checks on port 3030, tailored for Spring Boot's startup and runtime characteristics.
* **Rails Backend (`backend.yaml`)**: Introduced health probes on port 4000, optimized for fast API service startup and responsiveness.
* **Python Flask (`discounts.yaml`)**: Configured health probes on port 2814 for Flask's rapid startup and lightweight microservice checks.
* **Next.js Frontend (`frontend.yaml`)**: Replaced HTTP probes with TCP socket probes on port 3000, designed for fast Next.js startup and user-facing reliability.
* **Nginx Proxy (`nginx.yaml`)**: Added HTTP-based health probes on `/nginx_status` via a new `status` port (81), ensuring quick failure detection for the reverse proxy.

### Statefulset-Specific Probes
* **PostgreSQL (`postgres.yaml`)**: Added `pg_isready`-based probes for startup, readiness, and liveness, along with updated resource requests and limits.
* **Redis (`redis.yaml`)**: Implemented `redis-cli ping` probes for Redis, ensuring fast startup checks and critical dependency monitoring.

### Additional Enhancements
* **Nginx Service (`nginx.yaml`)**: Added a new port (81) for the `status` endpoint, supporting enhanced health monitoring via `/nginx_status`. [[1]](diffhunk://#diff-7795bee66576ae54337895fd19b50f129665f18ee8feb7a6e5969f022864be8cR11-R13) [[2]](diffhunk://#diff-7795bee66576ae54337895fd19b50f129665f18ee8feb7a6e5969f022864be8cR54-R56)
* **Backend Init Container (`backend.yaml`)**: Introduced a `wait-for-redis` init container to ensure Redis is available before the backend starts.## Description
<!--Provide a short description of what changes are being made and what services are being affected. Please include a Jira card link if applicable-->

## How to test
Perform the steps listed in the deployment section of the k8s manifest folder README.md


