### PR TITLE
Change name of ads container to ads-python

### DIFF
--- a/.github/workflows/ads.yml
+++ b/.github/workflows/ads.yml
@@ -43,5 +43,5 @@ jobs:
         context: ./services/ads/python
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: ghcr.io/datadog/storedog/ads:latest
+        tags: ghcr.io/datadog/storedog/ads-python:latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           IMAGES=(
             ghcr.io/datadog/storedog/backend
             ghcr.io/datadog/storedog/discounts
-            ghcr.io/datadog/storedog/ads
+            ghcr.io/datadog/storedog/ads-python
             ghcr.io/datadog/storedog/ads-java
             ghcr.io/datadog/storedog/nginx
             ghcr.io/datadog/storedog/frontend

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ This requires running a second Ads service in addition to the default Java Ads s
     ```yaml
       # OPTIONAL: Advertisement service (Python)
       ads-python:
-        image: ghcr.io/datadog/storedog/ads:${STOREDOG_IMAGE_VERSION:-latest}
-        build:
+        image: ghcr.io/datadog/storedog/ads-python:${STOREDOG_IMAGE_VERSION:-latest}
+        build: # Only used if building from source in development
           context: ./services/ads/python
         depends_on:
           - postgres
@@ -246,6 +246,8 @@ This requires running a second Ads service in addition to the default Java Ads s
           - DD_PROFILING_ENABLED=true
           - DD_PROFILING_TIMELINE_ENABLED=true
           - DD_PROFILING_ALLOCATION_ENABLED=true
+        volumes: # Only used in development
+          - ./services/ads/python:/app
         networks:
           - storedog-network
         labels:

--- a/k8s-manifests/README.md
+++ b/k8s-manifests/README.md
@@ -82,7 +82,7 @@ export REGISTRY_URL=localhost:5000
 ```
 
 ```bash
-SERVICE_NAME=ads
+SERVICE_NAME=discounts
 docker build -t $REGISTRY_URL/$SERVICE_NAME:latest ./services/$SERVICE_NAME && docker push $REGISTRY_URL/$SERVICE_NAME:latest
 ```
 

--- a/services/ads/README.md
+++ b/services/ads/README.md
@@ -149,29 +149,32 @@ The `ads` table has the following schema:
 To use the Python ads service, replace the `ads` definition with the following in your `docker-compose.yml` file:
 
 ```yaml
-ads:
-    build:
+  # OPTIONAL: Advertisement service (Python)
+  ads-python:
+    image: ghcr.io/datadog/storedog/ads-python:${STOREDOG_IMAGE_VERSION:-latest}
+    build: # Only used if building from source in development
       context: ./services/ads/python
-    command: wait-for-it postgres:5432 -- flask run --port=3030 --host=0.0.0.0 # If using any other port besides the default 9292, overriding the CMD is required
     depends_on:
       - postgres
       - dd-agent
     environment:
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_HOST=postgres
       - DD_AGENT_HOST=dd-agent
-      - DD_ENV=${DD_ENV}
-      - DD_SERVICE=store-ads
-      - DD_VERSION=${DD_VERSION_ADS-1.0.0}
-      - DD_RUNTIME_METRICS_ENABLED=true
+      - DD_ENV=${DD_ENV:-production}
+      - DD_SERVICE=store-ads-python
+      - DD_VERSION=${DD_VERSION_ADS_PYTHON:-1.0.0}
       - DD_PROFILING_ENABLED=true
       - DD_PROFILING_TIMELINE_ENABLED=true
       - DD_PROFILING_ALLOCATION_ENABLED=true
-    volumes:
+    volumes: # Only used in development
       - ./services/ads/python:/app
+    networks:
+      - storedog-network
     labels:
       com.datadoghq.ad.logs: '[{"source": "python"}]'
+```
 
 #### Kubernetes
 
@@ -216,7 +219,7 @@ spec:
             path: /var/run/datadog/
       containers:
         - name: ads
-          image: ${REGISTRY_URL}/ads:${SD_TAG}
+          image: ${REGISTRY_URL}/ads-python:${SD_TAG}
           ports:
             - containerPort: 3030
           env:

--- a/services/ads/k8s-manifests/ads-python.yaml
+++ b/services/ads/k8s-manifests/ads-python.yaml
@@ -36,7 +36,7 @@ spec:
             path: /var/run/datadog/
       containers:
         - name: ads-python
-          image: ${REGISTRY_URL}/ads:${SD_TAG}
+          image: ${REGISTRY_URL}/ads-python:${SD_TAG}
           ports:
             - containerPort: 3030
           env:


### PR DESCRIPTION
## Description
This changes the name of the ads container to ads-python. References in readme files have also been updated to match.



