### PR TITLE
removed unused value from configmap

### DIFF
--- a/k8s-manifests/storedog-app/configmaps/shared-config.yaml
+++ b/k8s-manifests/storedog-app/configmaps/shared-config.yaml
@@ -18,5 +18,4 @@ data:
   NEXT_PUBLIC_SPREE_CLIENT_HOST: /services/backend
   NEXT_PUBLIC_SPREE_IMAGE_HOST: /services/backend
   NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN: service-proxy
-  NEXT_PUBLIC_DD_ENV: storedog-k8s
   DD_ENV: storedog-k8s


### PR DESCRIPTION
## Description
This removes an unused value from the Storedog configmap. This variable is set in the `frontend.yaml` using `DD_ENV`.



