### PR TITLE
commented out the admission webhook patch

### DIFF
--- a/k8s-manifests/cluster-setup/ingress-controller/nginx-ingress.yaml
+++ b/k8s-manifests/cluster-setup/ingress-controller/nginx-ingress.yaml
@@ -590,62 +590,63 @@ spec:
       restartPolicy: OnFailure
       serviceAccountName: ingress-nginx-admission
   ttlSecondsAfterFinished: 0
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  labels:
-    app.kubernetes.io/component: admission-webhook
-    app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.13.2
-  name: ingress-nginx-admission-patch
-  namespace: ingress-nginx
-spec:
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/component: admission-webhook
-        app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/name: ingress-nginx
-        app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.13.2
-      name: ingress-nginx-admission-patch
-    spec:
-      automountServiceAccountToken: true
-      containers:
-      - args:
-        - patch
-        - --webhook-name=ingress-nginx-admission
-        - --namespace=$(POD_NAMESPACE)
-        - --patch-mutating=false
-        - --secret-name=ingress-nginx-admission
-        - --patch-failure-policy=Fail
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.2@sha256:050a34002d5bb4966849c880c56c91f5320372564245733b33d4b3461b4dbd24
-        imagePullPolicy: IfNotPresent
-        name: patch
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsGroup: 65532
-          runAsNonRoot: true
-          runAsUser: 65532
-          seccompProfile:
-            type: RuntimeDefault
-      nodeSelector:
-        kubernetes.io/os: linux
-      restartPolicy: OnFailure
-      serviceAccountName: ingress-nginx-admission
-  ttlSecondsAfterFinished: 0
+### Commented out the admission webhook patch job to prevent errors in lab environments
+# ---
+# apiVersion: batch/v1
+# kind: Job
+# metadata:
+#   labels:
+#     app.kubernetes.io/component: admission-webhook
+#     app.kubernetes.io/instance: ingress-nginx
+#     app.kubernetes.io/name: ingress-nginx
+#     app.kubernetes.io/part-of: ingress-nginx
+#     app.kubernetes.io/version: 1.13.2
+#   name: ingress-nginx-admission-patch
+#   namespace: ingress-nginx
+# spec:
+#   template:
+#     metadata:
+#       labels:
+#         app.kubernetes.io/component: admission-webhook
+#         app.kubernetes.io/instance: ingress-nginx
+#         app.kubernetes.io/name: ingress-nginx
+#         app.kubernetes.io/part-of: ingress-nginx
+#         app.kubernetes.io/version: 1.13.2
+#       name: ingress-nginx-admission-patch
+#     spec:
+#       automountServiceAccountToken: true
+#       containers:
+#       - args:
+#         - patch
+#         - --webhook-name=ingress-nginx-admission
+#         - --namespace=$(POD_NAMESPACE)
+#         - --patch-mutating=false
+#         - --secret-name=ingress-nginx-admission
+#         - --patch-failure-policy=Fail
+#         env:
+#         - name: POD_NAMESPACE
+#           valueFrom:
+#             fieldRef:
+#               fieldPath: metadata.namespace
+#         image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.2@sha256:050a34002d5bb4966849c880c56c91f5320372564245733b33d4b3461b4dbd24
+#         imagePullPolicy: IfNotPresent
+#         name: patch
+#         securityContext:
+#           allowPrivilegeEscalation: false
+#           capabilities:
+#             drop:
+#             - ALL
+#           readOnlyRootFilesystem: true
+#           runAsGroup: 65532
+#           runAsNonRoot: true
+#           runAsUser: 65532
+#           seccompProfile:
+#             type: RuntimeDefault
+#       nodeSelector:
+#         kubernetes.io/os: linux
+#       restartPolicy: OnFailure
+#       serviceAccountName: ingress-nginx-admission
+#   ttlSecondsAfterFinished: 0
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass


### PR DESCRIPTION
## Description
The nginx ingress controller  has issues when loading with Instruqt setup script. The admission webhook has been disabled. However, in DD, errors appear because the patch of the admission webhook fails.

Since this is not used, remove the patch as well.

## How to test
Using the K8s Dev Sandbox, clone the repo and checkout the branch.
Use the lab instructions to start Datadog for the cluster
Use the lab instructions to deploy the cluster setup
```sh
kubectl apply -R -f k8s-manifests/cluster-setup/
```
Log into DD and view the Kubernetes Explorer
Open the `ingress-nginx-controller`
No errors about failing to apply patch should appear


